### PR TITLE
Add comprehensive test suite for MCP-BOE tools

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,15 @@
       "Bash(uv --version)",
       "Bash(/Users/computingvictor/miniforge3/bin/uv python:*)",
       "Bash(/Users/computingvictor/miniforge3/bin/uv run:*)",
-      "Bash(curl -s \"https://www.boe.es/datosabiertos/api/legislacion-consolidada/id/BOE-A-2015-10566/metadatos\" -H \"Accept: application/json\")"
+      "Bash(curl -s \"https://www.boe.es/datosabiertos/api/legislacion-consolidada/id/BOE-A-2015-10566/metadatos\" -H \"Accept: application/json\")",
+      "Bash(Get-ChildItem -Path \"c:\\\\workspace-github\\\\MCP-BOE\" -Force)",
+      "Bash(Select-Object Name, Mode)",
+      "Bash(Get-ChildItem -Recurse -Directory -Name)",
+      "Bash(New-Item -ItemType Directory -Force -Path \"c:\\\\workspace-github\\\\MCP-BOE\\\\tests\")",
+      "Bash(Out-Null)",
+      "Bash(uv run *)",
+      "PowerShell(uv --version; \\(Get-Command uv\\).Source)",
+      "PowerShell($env:APPDATA)"
     ],
     "deny": [],
     "ask": []

--- a/README.md
+++ b/README.md
@@ -191,7 +191,9 @@ Compara dos normas e identifica relaciones de modificación o derogación entre 
 
 ## 🔧 Herramientas disponibles
 
-### 📜 Legislación Consolidada (5 herramientas)
+**31 herramientas en total** organizadas en 5 grupos.
+
+### 📜 Legislación Consolidada (9 herramientas)
 
 | Herramienta | Descripción | Parámetros clave |
 |-------------|-------------|------------------|
@@ -200,8 +202,12 @@ Compara dos normas e identifica relaciones de modificación o derogación entre 
 | `get_law_structure` | Índice completo de una norma (artículos, disposiciones, anexos) | `law_id` |
 | `get_law_text_block` | Texto de un artículo o disposición específica | `law_id`, `block_id` |
 | `find_related_laws` | Normas que modifican, derogan o son modificadas por una norma | `law_id`, `relation_type` |
+| `compare_law_versions` | Compara el texto de una norma entre dos fechas, detectando artículos añadidos, modificados o eliminados | `law_id`, `from_date`, `to_date`, `granularity` |
+| `search_law_articles` | Busca artículos concretos dentro de una norma sin descargar el texto completo | `law_id`, `query`, `search_in`, `limit` |
+| `get_law_metadata` | Obtiene solo los metadatos de una norma (rango, fecha, órgano, estado, enlaces) sin cargar el texto | `law_id` |
+| `list_related_laws` | Lista normas relacionadas con control granular sobre qué tipos de relación incluir | `law_id`, `include_derogating`, `include_development`, `include_references` |
 
-### 📰 Sumarios BOE/BORME (4 herramientas)
+### 📰 Sumarios BOE/BORME (7 herramientas)
 
 | Herramienta | Descripción | Parámetros clave |
 |-------------|-------------|------------------|
@@ -209,8 +215,11 @@ Compara dos normas e identifica relaciones de modificación o derogación entre 
 | `get_borme_summary` | Sumario del BORME (Registro Mercantil) | `date`, `province_filter`, `max_items` |
 | `search_recent_boe` | Busca documentos en los últimos N días | `days_back`, `search_terms`, `section_filter` |
 | `get_weekly_summary` | Estadísticas y resumen de una semana completa | `start_date`, `include_statistics` |
+| `get_boe_summary_range` | Agrega los sumarios de un rango de fechas (máx. 31 días) con filtro de sección | `from_date`, `to_date`, `section`, `max_items` |
+| `watch_boe_changes` | Radar normativo: busca publicaciones recientes por palabras clave | `days_back`, `keywords`, `sections`, `max_items` |
+| `group_summary_by_department` | Agrupa las publicaciones de un rango de fechas por departamento emisor | `from_date`, `to_date`, `sections`, `max_items_per_dept` |
 
-### 🏛️ Tablas Auxiliares (7 herramientas)
+### 🏛️ Tablas Auxiliares (10 herramientas)
 
 | Herramienta | Descripción |
 |-------------|-------------|
@@ -221,6 +230,18 @@ Compara dos normas e identifica relaciones de modificación o derogación entre 
 | `get_consolidation_states_table` | Estados de consolidación |
 | `search_auxiliary_data` | Búsqueda en todas las tablas a la vez |
 | `get_code_description` | Descripción de un código específico |
+| `search_departments_advanced` | Búsqueda avanzada de departamentos con filtro por código padre (jerarquía) | `search_term`, `active_only`, `parent_code`, `limit` |
+| `list_topics_for_law` | Lista las materias del vocabulario controlado de una norma concreta | `law_id` |
+| `suggest_auxiliary_filters` | Dado un texto libre, sugiere códigos de departamento, rango y materia para filtrar búsquedas | `query`, `max_suggestions` |
+
+### 🛠️ Calidad de vida para LLMs (4 herramientas)
+
+| Herramienta | Descripción | Parámetros clave |
+|-------------|-------------|------------------|
+| `summarize_law_sections` | Resumen estructurado de una norma con el primer párrafo de cada artículo | `law_id` |
+| `paginate_law_text` | Devuelve el texto de una norma por páginas usando un cursor opaco | `law_id`, `cursor`, `max_chars` |
+| `explain_law_structure` | Describe la estructura jerárquica de una norma con recuento de elementos por nivel | `law_id` |
+| `normalize_boe_reference` | Normaliza una referencia textual a una norma o sumario en campos estructurados | `reference_text` |
 
 ### 📄 Lectura de PDFs (1 herramienta)
 
@@ -396,9 +417,10 @@ MCP-BOE/
 │   ├── models/
 │   │   └── boe_models.py       # Modelos Pydantic y validadores
 │   ├── tools/
-│   │   ├── legislation.py      # 5 herramientas de legislación consolidada
-│   │   ├── summaries.py        # 4 herramientas de sumarios BOE/BORME
-│   │   ├── auxiliary.py        # 7 herramientas de tablas auxiliares
+│   │   ├── legislation.py      # 9 herramientas de legislación consolidada
+│   │   ├── summaries.py        # 7 herramientas de sumarios BOE/BORME
+│   │   ├── auxiliary.py        # 10 herramientas de tablas auxiliares
+│   │   ├── analysis.py         # 4 herramientas de calidad de vida para LLMs
 │   │   └── documents.py        # 1 herramienta de lectura de PDFs
 │   └── utils/
 │       └── http_client.py      # Cliente HTTP asíncrono con reintentos
@@ -434,7 +456,7 @@ uv run black src/
 ### v0.1.0
 
 - Implementación inicial del servidor MCP
-- **17 herramientas**: 5 de legislación, 4 de sumarios, 7 de tablas auxiliares, 1 de lectura de PDFs
+- **31 herramientas**: 9 de legislación, 7 de sumarios, 10 de tablas auxiliares, 4 de calidad de vida para LLMs, 1 de lectura de PDFs
 - Herramienta `read_boe_pdf`: descarga y extrae texto de PDFs del BOE por URL o por ID de norma
 - 4 prompts integrados: `buscar_legislacion`, `analizar_norma`, `resumen_boe_dia`, `comparar_normas`
 - 2 recursos MCP: `boe://help` y `boe://status`

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -14,6 +14,7 @@ from mcp_boe import BOEHTTPClient, BOEMCPServer
 from mcp_boe.tools.legislation import LegislationTools
 from mcp_boe.tools.summaries import SummaryTools
 from mcp_boe.tools.auxiliary import AuxiliaryTools
+from mcp_boe.tools.analysis import AnalysisTools
 
 
 async def example_search_legislation():
@@ -201,22 +202,299 @@ async def example_get_code_description():
             print()
 
 
+async def example_compare_law_versions():
+    """Ejemplo: Comparar versiones de una norma entre dos fechas."""
+    print("🔄 Ejemplo: Comparación de versiones")
+    print("=" * 60)
+
+    async with BOEHTTPClient() as client:
+        tools = LegislationTools(client)
+
+        print("Comparando Ley 40/2015 entre 2016 y 2021...")
+        results = await tools.compare_law_versions({
+            "law_id": "BOE-A-2015-10566",
+            "from_date": "20160101",
+            "to_date": "20210101",
+        })
+
+        for result in results:
+            text = result.text
+            if len(text) > 1500:
+                text = text[:1500] + "...\n\n[Contenido truncado para el ejemplo]"
+            print(text)
+            print()
+
+
+async def example_search_law_articles():
+    """Ejemplo: Buscar artículos por texto dentro de una norma."""
+    print("🔍 Ejemplo: Búsqueda en artículos")
+    print("=" * 60)
+
+    async with BOEHTTPClient() as client:
+        tools = LegislationTools(client)
+
+        print("Buscando 'competencia' en la Ley 40/2015...")
+        results = await tools.search_law_articles({
+            "law_id": "BOE-A-2015-10566",
+            "query": "competencia",
+            "limit": 5,
+        })
+
+        for result in results:
+            print(result.text)
+            print()
+
+
+async def example_get_law_metadata():
+    """Ejemplo: Obtener metadatos ligeros de una norma."""
+    print("📋 Ejemplo: Metadatos de norma")
+    print("=" * 60)
+
+    async with BOEHTTPClient() as client:
+        tools = LegislationTools(client)
+
+        print("Obteniendo metadatos de la Ley 40/2015...")
+        results = await tools.get_law_metadata({"law_id": "BOE-A-2015-10566"})
+
+        for result in results:
+            print(result.text)
+            print()
+
+
+async def example_list_related_laws():
+    """Ejemplo: Listar normas relacionadas con control granular."""
+    print("🔗 Ejemplo: Normas relacionadas")
+    print("=" * 60)
+
+    async with BOEHTTPClient() as client:
+        tools = LegislationTools(client)
+
+        print("Normas que derogan o son derogadas por Ley 40/2015...")
+        results = await tools.list_related_laws({
+            "law_id": "BOE-A-2015-10566",
+            "include_derogating": True,
+            "include_development": False,
+            "include_references": False,
+        })
+
+        for result in results:
+            print(result.text)
+            print()
+
+
+async def example_get_boe_summary_range():
+    """Ejemplo: Sumario BOE para un rango de fechas."""
+    print("📰 Ejemplo: Sumario de rango")
+    print("=" * 60)
+
+    async with BOEHTTPClient() as client:
+        tools = SummaryTools(client)
+
+        print("Obteniendo publicaciones BOE del 27 al 31 de mayo de 2024...")
+        results = await tools.get_boe_summary_range({
+            "from_date": "20240527",
+            "to_date": "20240531",
+            "max_items": 10,
+        })
+
+        for result in results:
+            text = result.text
+            if len(text) > 1500:
+                text = text[:1500] + "...\n\n[Contenido truncado para el ejemplo]"
+            print(text)
+            print()
+
+
+async def example_watch_boe_changes():
+    """Ejemplo: Radar normativo por palabras clave."""
+    print("📡 Ejemplo: Radar normativo")
+    print("=" * 60)
+
+    async with BOEHTTPClient() as client:
+        tools = SummaryTools(client)
+
+        print("Buscando 'inteligencia artificial' en el BOE de los últimos 30 días...")
+        results = await tools.watch_boe_changes({
+            "days_back": 30,
+            "keywords": "inteligencia artificial",
+            "max_items": 10,
+        })
+
+        for result in results:
+            print(result.text)
+            print()
+
+
+async def example_group_summary_by_department():
+    """Ejemplo: Agrupar publicaciones por departamento."""
+    print("🏛️ Ejemplo: Publicaciones por departamento")
+    print("=" * 60)
+
+    async with BOEHTTPClient() as client:
+        tools = SummaryTools(client)
+
+        recent_end = datetime.now().strftime("%Y%m%d")
+        recent_start = (datetime.now() - timedelta(days=7)).strftime("%Y%m%d")
+        print(f"Agrupando publicaciones del {recent_start} al {recent_end} por departamento...")
+        results = await tools.group_summary_by_department({
+            "from_date": recent_start,
+            "to_date": recent_end,
+            "max_items_per_dept": 3,
+        })
+
+        for result in results:
+            text = result.text
+            if len(text) > 2000:
+                text = text[:2000] + "...\n\n[Contenido truncado para el ejemplo]"
+            print(text)
+            print()
+
+
+async def example_search_departments_advanced():
+    """Ejemplo: Búsqueda avanzada de departamentos."""
+    print("🏛️ Ejemplo: Búsqueda avanzada de departamentos")
+    print("=" * 60)
+
+    async with BOEHTTPClient() as client:
+        tools = AuxiliaryTools(client)
+
+        print("Buscando secretarías de estado...")
+        results = await tools.search_departments_advanced({
+            "search_term": "Secretaría de Estado",
+            "active_only": True,
+            "limit": 10,
+        })
+
+        for result in results:
+            print(result.text)
+            print()
+
+
+async def example_list_topics_for_law():
+    """Ejemplo: Materias de una norma concreta."""
+    print("📚 Ejemplo: Materias de una norma")
+    print("=" * 60)
+
+    async with BOEHTTPClient() as client:
+        tools = AuxiliaryTools(client)
+
+        print("Listando materias de la Ley 40/2015...")
+        results = await tools.list_topics_for_law({"law_id": "BOE-A-2015-10566"})
+
+        for result in results:
+            print(result.text)
+            print()
+
+
+async def example_suggest_auxiliary_filters():
+    """Ejemplo: Sugerencias de filtros auxiliares desde texto libre."""
+    print("💡 Ejemplo: Sugerencias de filtros")
+    print("=" * 60)
+
+    async with BOEHTTPClient() as client:
+        tools = AuxiliaryTools(client)
+
+        print("Buscando sugerencias para 'medio ambiente'...")
+        results = await tools.suggest_auxiliary_filters({
+            "query": "medio ambiente",
+            "max_suggestions": 8,
+        })
+
+        for result in results:
+            print(result.text)
+            print()
+
+
+async def example_summarize_law_sections():
+    """Ejemplo: Resumen estructurado de una norma."""
+    print("📝 Ejemplo: Resumen de secciones")
+    print("=" * 60)
+
+    async with BOEHTTPClient() as client:
+        tools = AnalysisTools(client)
+
+        print("Resumiendo secciones de la Ley 40/2015...")
+        results = await tools.summarize_law_sections({"law_id": "BOE-A-2015-10566"})
+
+        for result in results:
+            text = result.text
+            if len(text) > 1500:
+                text = text[:1500] + "...\n\n[Contenido truncado para el ejemplo]"
+            print(text)
+            print()
+
+
+async def example_paginate_law_text():
+    """Ejemplo: Paginación de texto de una norma."""
+    print("📄 Ejemplo: Paginación de texto")
+    print("=" * 60)
+
+    async with BOEHTTPClient() as client:
+        tools = AnalysisTools(client)
+
+        print("Obteniendo primera página de la Ley 40/2015 (2000 caracteres)...")
+        results = await tools.paginate_law_text({
+            "law_id": "BOE-A-2015-10566",
+            "max_chars": 2000,
+        })
+
+        for result in results:
+            print(result.text)
+            print()
+
+
+async def example_normalize_boe_reference():
+    """Ejemplo: Normalizar referencias textuales a normas."""
+    print("🔤 Ejemplo: Normalización de referencias")
+    print("=" * 60)
+
+    async with BOEHTTPClient() as client:
+        tools = AnalysisTools(client)
+
+        references = [
+            "Ley 40/2015",
+            "Real Decreto 1/2020",
+            "BOE-A-2015-10566",
+            "BOE del 3 de mayo de 2024",
+            "Ley Orgánica 3/2018",
+        ]
+
+        for ref in references:
+            results = await tools.normalize_boe_reference({"reference_text": ref})
+            print(f"  «{ref}» →")
+            print(f"    {results[0].text.strip()}")
+            print()
+
+
 async def run_all_examples():
     """Ejecuta todos los ejemplos."""
     print("🚀 Ejecutando todos los ejemplos del MCP BOE")
     print("=" * 80)
     print()
-    
+
     examples = [
         ("Búsqueda de legislación", example_search_legislation),
         ("Detalles de norma", example_get_law_details),
         ("Estructura de norma", example_get_law_structure),
+        ("Comparar versiones", example_compare_law_versions),
+        ("Buscar artículos", example_search_law_articles),
+        ("Metadatos de norma", example_get_law_metadata),
+        ("Normas relacionadas", example_list_related_laws),
         ("Sumario del BOE", example_get_boe_summary),
         ("Búsqueda reciente BOE", example_search_recent_boe),
+        ("Sumario por rango", example_get_boe_summary_range),
+        ("Radar normativo", example_watch_boe_changes),
+        ("Publicaciones por dpto.", example_group_summary_by_department),
         ("Tabla de departamentos", example_get_departments),
         ("Rangos normativos", example_get_legal_ranges),
         ("Búsqueda auxiliares", example_search_auxiliary),
         ("Descripción de código", example_get_code_description),
+        ("Departamentos avanzado", example_search_departments_advanced),
+        ("Materias de norma", example_list_topics_for_law),
+        ("Sugerencias de filtros", example_suggest_auxiliary_filters),
+        ("Resumen de secciones", example_summarize_law_sections),
+        ("Paginación de texto", example_paginate_law_text),
+        ("Normalizar referencia", example_normalize_boe_reference),
     ]
     
     for i, (name, func) in enumerate(examples, 1):

--- a/src/mcp_boe/models/boe_models.py
+++ b/src/mcp_boe/models/boe_models.py
@@ -465,22 +465,19 @@ class SearchParameters(BaseModel):
 # MODELOS PARA RESPUESTAS DE ERROR
 # ============================================================================
 
-class APIError(BaseModel):
+class APIError(Exception):
     """Error de la API del BOE."""
-    codigo: int = Field(..., description="Código de error HTTP")
-    mensaje: str = Field(..., description="Mensaje de error")
-    detalles: Optional[str] = Field(None, description="Detalles adicionales del error")
-    timestamp: datetime = Field(default_factory=datetime.now, description="Momento del error")
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "codigo": 404,
-                "mensaje": "La información solicitada no existe",
-                "detalles": "El identificador BOE-A-2025-99999 no se encontró",
-                "timestamp": "2025-01-23T10:30:00Z"
-            }
-        }
+    def __init__(
+        self,
+        codigo: int,
+        mensaje: str,
+        detalles: Optional[str] = None,
+    ) -> None:
+        self.codigo = codigo
+        self.mensaje = mensaje
+        self.detalles = detalles
+        super().__init__(mensaje)
 
 
 # ============================================================================
@@ -529,6 +526,48 @@ def format_date_for_api(date_input: Union[str, datetime]) -> str:
 
 
 # ============================================================================
+# MODELOS PARA NUEVAS HERRAMIENTAS AVANZADAS
+# ============================================================================
+
+class LawVersionChange(BaseModel):
+    """Cambio detectado entre dos versiones de un bloque de una norma."""
+    unit_type: str = Field(..., description="Tipo de unidad (articulo, capitulo, titulo)")
+    unit_id: str = Field(..., description="Identificador del bloque (ej: 'a14')")
+    unit_title: str = Field(..., description="Título del bloque")
+    change_type: str = Field(..., description="Tipo de cambio: added, modified, removed")
+    old_text: Optional[str] = Field(None, description="Texto en la fecha inicial (si aplica)")
+    new_text: Optional[str] = Field(None, description="Texto en la fecha final (si aplica)")
+
+    @validator('change_type')
+    def validate_change_type(cls, v):
+        if v not in ('added', 'modified', 'removed'):
+            raise ValueError(f"change_type inválido: {v}")
+        return v
+
+
+class ArticleMatch(BaseModel):
+    """Resultado de búsqueda de artículos dentro de una norma."""
+    article_id: str = Field(..., description="ID del bloque (ej: 'a14')")
+    title: str = Field(..., description="Título del artículo")
+    snippet: str = Field(..., description="Fragmento relevante del texto")
+    full_text: Optional[str] = Field(None, description="Texto completo del artículo (opcional)")
+
+
+class PaginatedLawText(BaseModel):
+    """Fragmento paginado del texto de una norma."""
+    chunk_text: str = Field(..., description="Texto del fragmento actual")
+    articles_included: List[str] = Field(..., description="IDs de los bloques incluidos en el fragmento")
+    next_cursor: Optional[str] = Field(None, description="Cursor para la siguiente página (None si es la última)")
+
+
+class FilterSuggestion(BaseModel):
+    """Sugerencia de filtro de tablas auxiliares para una consulta."""
+    type: str = Field(..., description="Tipo de filtro: department, topic, range, scope, state")
+    code: str = Field(..., description="Código del filtro")
+    label: str = Field(..., description="Etiqueta descriptiva")
+
+
+# ============================================================================
 # EXPORTS
 # ============================================================================
 
@@ -567,6 +606,12 @@ __all__ = [
     'SearchQuery',
     'SearchParameters',
     
+    # Nuevos modelos para herramientas avanzadas
+    'LawVersionChange',
+    'ArticleMatch',
+    'PaginatedLawText',
+    'FilterSuggestion',
+
     # Utilidades
     'validate_boe_identifier',
     'validate_date_format',

--- a/src/mcp_boe/server.py
+++ b/src/mcp_boe/server.py
@@ -20,6 +20,7 @@ from .tools.legislation import LegislationTools
 from .tools.summaries import SummaryTools
 from .tools.auxiliary import AuxiliaryTools
 from .tools.documents import DocumentTools
+from .tools.analysis import AnalysisTools
 
 # Configurar logging
 logging.basicConfig(level=logging.INFO)
@@ -36,6 +37,7 @@ class BOEMCPServer:
         self.legislation_tools = None
         self.summary_tools = None
         self.auxiliary_tools = None
+        self.analysis_tools = None
         self.document_tools = DocumentTools()
         self._setup_handlers()
 
@@ -55,6 +57,9 @@ class BOEMCPServer:
             
             if self.auxiliary_tools:
                 tools.extend(self.auxiliary_tools.get_tools())
+
+            if self.analysis_tools:
+                tools.extend(self.analysis_tools.get_tools())
 
             tools.extend(self.document_tools.get_tools())
 
@@ -92,6 +97,24 @@ class BOEMCPServer:
                 "get_consolidation_states_table":  lambda a: self.auxiliary_tools.get_consolidation_states_table(a),
                 "search_auxiliary_data":           lambda a: self.auxiliary_tools.search_auxiliary_data(a),
                 "get_code_description":            lambda a: self.auxiliary_tools.get_code_description(a),
+                # Legislación avanzada (grupo A)
+                "compare_law_versions":            lambda a: self.legislation_tools.compare_law_versions(a),
+                "search_law_articles":             lambda a: self.legislation_tools.search_law_articles(a),
+                "get_law_metadata":                lambda a: self.legislation_tools.get_law_metadata(a),
+                "list_related_laws":               lambda a: self.legislation_tools.list_related_laws(a),
+                # Sumarios avanzados (grupo B)
+                "get_boe_summary_range":           lambda a: self.summary_tools.get_boe_summary_range(a),
+                "watch_boe_changes":               lambda a: self.summary_tools.watch_boe_changes(a),
+                "group_summary_by_department":     lambda a: self.summary_tools.group_summary_by_department(a),
+                # Tablas auxiliares avanzadas (grupo C)
+                "search_departments_advanced":     lambda a: self.auxiliary_tools.search_departments_advanced(a),
+                "list_topics_for_law":             lambda a: self.auxiliary_tools.list_topics_for_law(a),
+                "suggest_auxiliary_filters":       lambda a: self.auxiliary_tools.suggest_auxiliary_filters(a),
+                # Calidad de vida (grupo D)
+                "summarize_law_sections":          lambda a: self.analysis_tools.summarize_law_sections(a),
+                "paginate_law_text":               lambda a: self.analysis_tools.paginate_law_text(a),
+                "explain_law_structure":           lambda a: self.analysis_tools.explain_law_structure(a),
+                "normalize_boe_reference":         lambda a: self.analysis_tools.normalize_boe_reference(a),
                 # Documentos PDF
                 "read_boe_pdf":                    lambda a: self.document_tools.read_boe_pdf(a),
             }
@@ -420,7 +443,8 @@ Obtiene la descripción de un código específico.
         self.legislation_tools = LegislationTools(self.http_client)
         self.summary_tools = SummaryTools(self.http_client)
         self.auxiliary_tools = AuxiliaryTools(self.http_client)
-        
+        self.analysis_tools = AnalysisTools(self.http_client)
+
         logger.info("Servidor MCP BOE inicializado correctamente")
 
     async def cleanup(self):
@@ -579,7 +603,8 @@ class BOEMCPServerWithConfig(BOEMCPServer):
         self.legislation_tools = LegislationTools(self.http_client)
         self.summary_tools = SummaryTools(self.http_client)
         self.auxiliary_tools = AuxiliaryTools(self.http_client)
-        
+        self.analysis_tools = AnalysisTools(self.http_client)
+
         logger.info("Servidor MCP BOE inicializado con configuración personalizada")
 
 

--- a/src/mcp_boe/tools/analysis.py
+++ b/src/mcp_boe/tools/analysis.py
@@ -1,0 +1,695 @@
+"""
+Herramientas MCP de calidad de vida para el análisis de legislación del BOE.
+
+Este módulo contiene herramientas auxiliares que facilitan el trabajo con normas
+largas: paginación de texto, esqueleto estructural, normalización de referencias
+y explicación compacta de la estructura.
+"""
+
+import base64
+import logging
+import re
+from typing import Dict, Any, List, Optional
+
+from mcp.types import TextContent, Tool
+
+from ..utils.http_client import BOEHTTPClient, APIError
+from ..models.boe_models import validate_boe_identifier
+
+logger = logging.getLogger(__name__)
+
+# Meses en español para normalización de fechas en referencias
+_MESES_ES = {
+    'enero': '01', 'febrero': '02', 'marzo': '03', 'abril': '04',
+    'mayo': '05', 'junio': '06', 'julio': '07', 'agosto': '08',
+    'septiembre': '09', 'octubre': '10', 'noviembre': '11', 'diciembre': '12',
+}
+
+
+class AnalysisTools:
+    """Herramientas de análisis y calidad de vida para normas del BOE."""
+
+    def __init__(self, http_client: BOEHTTPClient):
+        self.client = http_client
+
+    def get_tools(self) -> List[Tool]:
+        """Retorna la lista de herramientas disponibles."""
+        return [
+            Tool(
+                name="summarize_law_sections",
+                description=(
+                    "Devuelve un esqueleto de la norma: lista de bloques (preámbulo, artículos, "
+                    "disposiciones) con su título y el primer párrafo de cada uno, sin texto completo. "
+                    "Útil para obtener una visión rápida del contenido antes de profundizar."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "law_id": {
+                            "type": "string",
+                            "pattern": "^BOE-[A-Z]-\\d{4}-\\d{1,5}$",
+                            "description": "Identificador único de la norma (ej: 'BOE-A-2015-10566')"
+                        }
+                    },
+                    "required": ["law_id"],
+                    "additionalProperties": False
+                }
+            ),
+            Tool(
+                name="paginate_law_text",
+                description=(
+                    "Devuelve el texto de una norma en fragmentos manejables. "
+                    "Permite al LLM leer normas largas trozo a trozo sin cargarlas enteras. "
+                    "Usa el cursor devuelto en next_cursor para obtener el siguiente fragmento."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "law_id": {
+                            "type": "string",
+                            "pattern": "^BOE-[A-Z]-\\d{4}-\\d{1,5}$",
+                            "description": "Identificador único de la norma"
+                        },
+                        "cursor": {
+                            "type": "string",
+                            "description": "Cursor de paginación (omitir o dejar vacío para la primera página)"
+                        },
+                        "max_chars": {
+                            "type": "integer",
+                            "minimum": 500,
+                            "maximum": 10000,
+                            "default": 4000,
+                            "description": "Máximo de caracteres por fragmento (default: 4000)"
+                        }
+                    },
+                    "required": ["law_id"],
+                    "additionalProperties": False
+                }
+            ),
+            Tool(
+                name="explain_law_structure",
+                description=(
+                    "Devuelve un resumen estructural compacto de una norma: "
+                    "lista de niveles con tipo, id, título y número de hijos directos. "
+                    "Más conciso que get_law_structure, ideal para entender la organización rápidamente."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "law_id": {
+                            "type": "string",
+                            "pattern": "^BOE-[A-Z]-\\d{4}-\\d{1,5}$",
+                            "description": "Identificador único de la norma"
+                        }
+                    },
+                    "required": ["law_id"],
+                    "additionalProperties": False
+                }
+            ),
+            Tool(
+                name="normalize_boe_reference",
+                description=(
+                    "Convierte una referencia libre a una norma o BOE en una forma normalizada. "
+                    "Acepta textos como 'Ley 40/2015', 'Real Decreto 123/2020', "
+                    "'Orden TED/1234/2023', 'BOE del 3 de mayo de 2024, sec. I', etc. "
+                    "Devuelve el tipo, identificador normalizado y otros campos extraídos."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "reference_text": {
+                            "type": "string",
+                            "description": "Texto libre con la referencia a normalizar"
+                        }
+                    },
+                    "required": ["reference_text"],
+                    "additionalProperties": False
+                }
+            ),
+        ]
+
+    # =========================================================================
+    # summarize_law_sections
+    # =========================================================================
+
+    async def summarize_law_sections(self, arguments: Dict[str, Any]) -> List[TextContent]:
+        """Devuelve un esqueleto de la norma con título y primer párrafo de cada bloque.
+
+        Args:
+            arguments: Diccionario con law_id.
+
+        Returns:
+            TextContent con la estructura resumida en markdown.
+        """
+        try:
+            law_id = arguments['law_id']
+
+            if not validate_boe_identifier(law_id):
+                raise ValueError(f"Identificador de norma inválido: {law_id}")
+
+            logger.info(f"Generando esqueleto de norma {law_id}")
+
+            response = await self.client.get_law_by_id(law_id, 'texto')
+
+            if not response.get('data'):
+                return [TextContent(
+                    type="text",
+                    text=f"No se encontró texto para la norma {law_id}."
+                )]
+
+            bloques = response['data'].get('texto', [])
+            if not isinstance(bloques, list):
+                bloques = [bloques] if bloques else []
+
+            if not bloques:
+                return [TextContent(
+                    type="text",
+                    text=f"La norma {law_id} no contiene bloques de texto."
+                )]
+
+            formatted = self._format_law_skeleton(bloques, law_id)
+            return [TextContent(type="text", text=formatted)]
+
+        except APIError as e:
+            logger.error(f"Error de API generando esqueleto de {law_id}: {e}")
+            return [TextContent(type="text", text=f"Error accediendo a la norma {law_id}: {e.mensaje}")]
+        except Exception as e:
+            logger.error(f"Error inesperado generando esqueleto: {e}")
+            return [TextContent(type="text", text=f"Error interno: {str(e)}")]
+
+    def _format_law_skeleton(self, bloques: List[Dict[str, Any]], law_id: str) -> str:
+        """Formatea el esqueleto de la norma con primer párrafo de cada bloque."""
+        output = [f"# 📋 Esqueleto de la norma `{law_id}`", ""]
+
+        tipo_emojis = {
+            'preambulo': '📖',
+            'precepto': '📄',
+            'parte_dispositiva': '⚖️',
+            'parte_final': '📝',
+            'instrumento': '📎',
+            'nota_inicial': '🔔',
+            'encabezado': '🏷️',
+            'firma': '✍️',
+        }
+
+        for bloque in bloques:
+            block_id = bloque.get('id', 'N/A')
+            titulo = bloque.get('titulo', 'Sin título')
+            tipo = bloque.get('tipo', 'desconocido')
+            emoji = tipo_emojis.get(tipo, '📌')
+
+            output.append(f"## {emoji} {titulo} (`{block_id}`)")
+
+            versiones = bloque.get('versiones', [])
+            if not isinstance(versiones, list):
+                versiones = [versiones] if versiones else []
+
+            if versiones:
+                # Usar la versión más reciente
+                version = versiones[0]
+                html = version.get('contenido_html', '')
+                if html:
+                    first_para = self._extract_first_paragraph(html)
+                    if first_para:
+                        output.append(f"> {first_para}")
+
+            output.append("")
+
+        output.append("---")
+        output.append(
+            "💡 Usa `get_law_text_block` con el ID entre paréntesis para el texto completo de cada bloque, "
+            "o `paginate_law_text` para leer la norma en fragmentos."
+        )
+        return "\n".join(output)
+
+    def _extract_first_paragraph(self, html: str) -> str:
+        """Extrae el primer párrafo de texto de un fragmento HTML."""
+        # Buscar primer <p>...</p>
+        match = re.search(r'<p[^>]*>(.*?)</p>', html, re.DOTALL | re.IGNORECASE)
+        if match:
+            text = match.group(1)
+        else:
+            text = html
+
+        # Limpiar tags HTML básicos
+        text = re.sub(r'<[^>]+>', ' ', text)
+        text = re.sub(r'\s+', ' ', text).strip()
+
+        # Truncar a 200 caracteres
+        if len(text) > 200:
+            text = text[:197] + '…'
+        return text
+
+    # =========================================================================
+    # paginate_law_text
+    # =========================================================================
+
+    async def paginate_law_text(self, arguments: Dict[str, Any]) -> List[TextContent]:
+        """Devuelve el texto de una norma en fragmentos paginados.
+
+        El cursor es un entero codificado en base64 que indica el índice
+        del primer bloque de la página actual. Es determinista y estable
+        mientras la norma no cambie.
+
+        Args:
+            arguments: Diccionario con law_id, cursor opcional y max_chars.
+
+        Returns:
+            TextContent con chunk_text, articles_included y next_cursor.
+        """
+        try:
+            law_id = arguments['law_id']
+            cursor_str = arguments.get('cursor') or ''
+            max_chars = arguments.get('max_chars', 4000)
+
+            if not validate_boe_identifier(law_id):
+                raise ValueError(f"Identificador de norma inválido: {law_id}")
+
+            # Decodificar cursor
+            start_index = 0
+            if cursor_str:
+                try:
+                    start_index = int(base64.b64decode(cursor_str.encode()).decode())
+                except Exception:
+                    raise ValueError(f"Cursor inválido: {cursor_str}")
+
+            logger.info(f"Paginando texto de {law_id} desde bloque {start_index}, max_chars={max_chars}")
+
+            response = await self.client.get_law_by_id(law_id, 'texto')
+
+            if not response.get('data'):
+                return [TextContent(type="text", text=f"No se encontró texto para la norma {law_id}.")]
+
+            bloques = response['data'].get('texto', [])
+            if not isinstance(bloques, list):
+                bloques = [bloques] if bloques else []
+
+            if start_index >= len(bloques):
+                return [TextContent(
+                    type="text",
+                    text=(
+                        f"## Paginación de `{law_id}`\n\n"
+                        "**No hay más contenido.** El cursor proporcionado apunta más allá del último bloque.\n\n"
+                        "**Artículos incluidos:** (ninguno)\n"
+                        "**Siguiente cursor:** (fin)"
+                    )
+                )]
+
+            # Construir fragmento acumulando bloques hasta max_chars
+            chunk_parts: List[str] = []
+            articles_included: List[str] = []
+            current_chars = 0
+            current_index = start_index
+
+            for idx in range(start_index, len(bloques)):
+                bloque = bloques[idx]
+                block_id = bloque.get('id', f'bloque_{idx}')
+                titulo = bloque.get('titulo', '')
+
+                versiones = bloque.get('versiones', [])
+                if not isinstance(versiones, list):
+                    versiones = [versiones] if versiones else []
+
+                html = versiones[0].get('contenido_html', '') if versiones else ''
+                clean_text = self._clean_html(html)
+
+                block_text = f"### {titulo} (`{block_id}`)\n\n{clean_text}\n" if titulo else f"{clean_text}\n"
+
+                if current_chars + len(block_text) > max_chars and chunk_parts:
+                    # No cabe en la página actual; parar aquí
+                    break
+
+                chunk_parts.append(block_text)
+                articles_included.append(block_id)
+                current_chars += len(block_text)
+                current_index = idx + 1
+
+            # Calcular next_cursor
+            next_cursor: Optional[str] = None
+            if current_index < len(bloques):
+                next_cursor = base64.b64encode(str(current_index).encode()).decode()
+
+            chunk_text = "\n".join(chunk_parts)
+            page_num = start_index + 1
+
+            result_lines = [
+                f"## 📄 Texto de `{law_id}` — desde bloque {start_index + 1}",
+                "",
+                chunk_text,
+                "---",
+                f"**Bloques incluidos:** {', '.join(f'`{a}`' for a in articles_included)}",
+            ]
+            if next_cursor:
+                result_lines.append(f"**Siguiente cursor:** `{next_cursor}`")
+                result_lines.append("*(Usa `paginate_law_text` con este cursor para continuar.)*")
+            else:
+                result_lines.append("**Fin del documento.** No hay más páginas.")
+
+            return [TextContent(type="text", text="\n".join(result_lines))]
+
+        except APIError as e:
+            logger.error(f"Error de API paginando {law_id}: {e}")
+            return [TextContent(type="text", text=f"Error accediendo a la norma {law_id}: {e.mensaje}")]
+        except Exception as e:
+            logger.error(f"Error inesperado paginando texto: {e}")
+            return [TextContent(type="text", text=f"Error interno: {str(e)}")]
+
+    def _clean_html(self, html: str) -> str:
+        """Limpia HTML básico para texto plano."""
+        text = re.sub(r'</p>\s*<p[^>]*>', '\n\n', html)
+        text = re.sub(r'<p[^>]*>', '', text)
+        text = re.sub(r'</p>', '', text)
+        text = re.sub(r'<li[^>]*>', '\n• ', text)
+        text = re.sub(r'</li>', '', text)
+        text = re.sub(r'</?[uo]l[^>]*>', '', text)
+        text = re.sub(r'<strong[^>]*>(.*?)</strong>', r'**\1**', text)
+        text = re.sub(r'<em[^>]*>(.*?)</em>', r'*\1*', text)
+        text = re.sub(r'<[^>]+>', '', text)
+        text = re.sub(r'\n{3,}', '\n\n', text)
+        return text.strip()
+
+    # =========================================================================
+    # explain_law_structure
+    # =========================================================================
+
+    async def explain_law_structure(self, arguments: Dict[str, Any]) -> List[TextContent]:
+        """Devuelve una lista compacta con la estructura de la norma y conteo de hijos.
+
+        Args:
+            arguments: Diccionario con law_id.
+
+        Returns:
+            TextContent con la estructura compacta en markdown.
+        """
+        try:
+            law_id = arguments['law_id']
+
+            if not validate_boe_identifier(law_id):
+                raise ValueError(f"Identificador de norma inválido: {law_id}")
+
+            logger.info(f"Explicando estructura de norma {law_id}")
+
+            response = await self.client.get_law_by_id(law_id, 'texto/indice')
+
+            if not response.get('data'):
+                return [TextContent(type="text", text=f"No se encontró estructura para la norma {law_id}.")]
+
+            structure_data = response['data']
+            formatted = self._format_compact_structure(structure_data, law_id)
+            return [TextContent(type="text", text=formatted)]
+
+        except APIError as e:
+            logger.error(f"Error de API obteniendo estructura de {law_id}: {e}")
+            return [TextContent(type="text", text=f"Error accediendo a la norma {law_id}: {e.mensaje}")]
+        except Exception as e:
+            logger.error(f"Error inesperado explicando estructura: {e}")
+            return [TextContent(type="text", text=f"Error interno: {str(e)}")]
+
+    def _format_compact_structure(self, structure_data: Dict[str, Any], law_id: str) -> str:
+        """Formatea la estructura del índice de forma compacta."""
+        output = [f"# 🗂️ Estructura compacta de `{law_id}`", ""]
+
+        bloques = structure_data.get('bloque', [])
+        if not isinstance(bloques, list):
+            bloques = [bloques] if bloques else []
+
+        if not bloques:
+            return f"No se encontró información de estructura para `{law_id}`."
+
+        # Clasificar bloques y agrupar por tipo
+        tipos_orden = [
+            ('preambulo', '📖 Preámbulo'),
+            ('precepto', '📄 Articulado'),
+            ('parte_dispositiva', '⚖️ Parte dispositiva'),
+            ('parte_final', '📝 Parte final'),
+            ('instrumento', '📎 Instrumentos/Anexos'),
+        ]
+
+        # Agrupar por prefijo de ID para detectar capítulos/títulos
+        grupos: Dict[str, List[Dict]] = {}
+        for bloque in bloques:
+            block_id = bloque.get('id', 'N/A')
+            titulo = bloque.get('titulo', 'Sin título')
+            fecha = bloque.get('fecha_actualizacion', '')
+
+            # Determinar grupo
+            if block_id.startswith('a'):
+                grupo = 'precepto'
+            elif block_id in ('pr', 'preambulo'):
+                grupo = 'preambulo'
+            elif block_id.startswith('dd'):
+                grupo = 'parte_dispositiva'
+            elif block_id.startswith('d'):
+                grupo = 'parte_final'
+            else:
+                grupo = 'instrumento'
+
+            if grupo not in grupos:
+                grupos[grupo] = []
+            grupos[grupo].append({'id': block_id, 'titulo': titulo, 'fecha': fecha})
+
+        for tipo_key, tipo_label in tipos_orden:
+            items = grupos.get(tipo_key, [])
+            if not items:
+                continue
+
+            output.append(f"## {tipo_label} ({len(items)} elemento{'s' if len(items) != 1 else ''})")
+            output.append("")
+
+            for item in items:
+                fecha_str = ''
+                if item['fecha'] and len(item['fecha']) == 8:
+                    try:
+                        from datetime import datetime
+                        d = datetime.strptime(item['fecha'], '%Y%m%d')
+                        fecha_str = f" *(actualizado {d.strftime('%d/%m/%Y')})*"
+                    except ValueError:
+                        pass
+                output.append(f"- **{item['titulo']}** `{item['id']}`{fecha_str}")
+
+            output.append("")
+
+        output.append("---")
+        output.append("💡 Usa `get_law_text_block` con cualquiera de los IDs para leer ese bloque.")
+        return "\n".join(output)
+
+    # =========================================================================
+    # normalize_boe_reference
+    # =========================================================================
+
+    async def normalize_boe_reference(self, arguments: Dict[str, Any]) -> List[TextContent]:
+        """Normaliza una referencia libre a una norma o edición del BOE.
+
+        No realiza llamadas a la API; trabaja exclusivamente con expresiones regulares.
+
+        Args:
+            arguments: Diccionario con reference_text.
+
+        Returns:
+            TextContent con los campos normalizados.
+        """
+        try:
+            reference_text = arguments['reference_text'].strip()
+            if not reference_text:
+                raise ValueError("El texto de referencia no puede estar vacío.")
+
+            logger.info(f"Normalizando referencia: '{reference_text}'")
+
+            result = self._normalize_reference(reference_text)
+            formatted = self._format_normalized_reference(reference_text, result)
+            return [TextContent(type="text", text=formatted)]
+
+        except Exception as e:
+            logger.error(f"Error normalizando referencia: {e}")
+            return [TextContent(type="text", text=f"Error interno: {str(e)}")]
+
+    def _normalize_reference(self, text: str) -> Dict[str, Any]:
+        """Aplica patrones regex para normalizar una referencia a norma/BOE."""
+        # 1. BOE ID directo
+        m = re.search(r'BOE-[A-Z]-\d{4}-\d{1,5}', text)
+        if m:
+            return {
+                'type': 'law',
+                'law_id': m.group(0),
+                'normalized_string': m.group(0),
+            }
+
+        # 2. Ley Orgánica X/YYYY o Ley X/YYYY
+        m = re.search(
+            r'Ley\s+(Org[aá]nica\s+)?(\d+)/(\d{4})',
+            text, re.IGNORECASE
+        )
+        if m:
+            org = 'Orgánica ' if m.group(1) else ''
+            numero, anio = m.group(2), m.group(3)
+            norm = f"Ley {org}{numero}/{anio}"
+            return {
+                'type': 'law',
+                'normalized_string': norm,
+                'number': numero,
+                'year': anio,
+                'is_organic': bool(m.group(1)),
+            }
+
+        # 3. Real Decreto-ley / Real Decreto Legislativo / Real Decreto
+        m = re.search(
+            r'Real\s+Decreto(-ley|-legislativo)?\s+(\d+)/(\d{4})',
+            text, re.IGNORECASE
+        )
+        if m:
+            sufijo = (m.group(1) or '').replace('-', '-').strip('-').capitalize()
+            tipo = f"Real Decreto{('-' + sufijo) if sufijo else ''}"
+            numero, anio = m.group(2), m.group(3)
+            norm = f"{tipo} {numero}/{anio}"
+            return {
+                'type': 'law',
+                'normalized_string': norm,
+                'number': numero,
+                'year': anio,
+            }
+
+        # 4. Orden ministerial: Orden AAA/NNN/YYYY
+        m = re.search(
+            r'Orden\s+([A-Z]{2,6})/(\d+)/(\d{4})',
+            text, re.IGNORECASE
+        )
+        if m:
+            dept, numero, anio = m.group(1).upper(), m.group(2), m.group(3)
+            norm = f"Orden {dept}/{numero}/{anio}"
+            return {
+                'type': 'order',
+                'normalized_string': norm,
+                'department_code': dept,
+                'number': numero,
+                'year': anio,
+            }
+
+        # 5. Resolución de fecha "Resolución de X de [mes] de YYYY"
+        m = re.search(
+            r'Resoluci[oó]n\s+de\s+(\d{1,2})\s+de\s+(\w+)\s+de\s+(\d{4})',
+            text, re.IGNORECASE
+        )
+        if m:
+            dia, mes_str, anio = m.group(1), m.group(2).lower(), m.group(3)
+            mes = _MESES_ES.get(mes_str)
+            date_str = f"{anio}{mes}{dia.zfill(2)}" if mes else None
+            norm = f"Resolución de {dia} de {mes_str.capitalize()} de {anio}"
+            return {
+                'type': 'resolution',
+                'normalized_string': norm,
+                'date': date_str,
+            }
+
+        # 6. BOE del/de [día] de [mes] de [año]
+        m = re.search(
+            r'BOE\s+del?\s+(\d{1,2})\s+de\s+(\w+)\s+de\s+(\d{4})',
+            text, re.IGNORECASE
+        )
+        if m:
+            dia, mes_str, anio = m.group(1), m.group(2).lower(), m.group(3)
+            mes = _MESES_ES.get(mes_str)
+            date_api = f"{anio}{mes}{dia.zfill(2)}" if mes else None
+            section = None
+            sec_m = re.search(r'sec(?:ci[oó]n)?\s*\.?\s*([IVX]+|\d+[AB]?)', text, re.IGNORECASE)
+            if sec_m:
+                section = sec_m.group(1).upper()
+            norm = f"BOE del {dia} de {mes_str.capitalize()} de {anio}"
+            if section:
+                norm += f", sección {section}"
+            return {
+                'type': 'boe_issue',
+                'normalized_string': norm,
+                'date': date_api,
+                'section': section,
+            }
+
+        # 7. BOE de fecha numérica DD/MM/YYYY
+        m = re.search(r'BOE\s+de\s+(\d{1,2})[/\-](\d{1,2})[/\-](\d{4})', text, re.IGNORECASE)
+        if m:
+            dia, mes, anio = m.group(1).zfill(2), m.group(2).zfill(2), m.group(3)
+            date_api = f"{anio}{mes}{dia}"
+            norm = f"BOE de {dia}/{mes}/{anio}"
+            return {
+                'type': 'boe_issue',
+                'normalized_string': norm,
+                'date': date_api,
+                'section': None,
+            }
+
+        # 8. Número de BOE: "BOE núm. NNN de YYYY" o "BOE n.º NNN"
+        m = re.search(r'BOE\s+n[uú]m\.?\s*(\d+)', text, re.IGNORECASE)
+        if m:
+            return {
+                'type': 'boe_issue',
+                'normalized_string': f"BOE núm. {m.group(1)}",
+                'boe_number': m.group(1),
+                'date': None,
+                'section': None,
+            }
+
+        # No reconocido
+        return {
+            'type': 'unknown',
+            'normalized_string': text,
+            'explanation': 'No se reconoció el formato de la referencia.',
+        }
+
+    def _format_normalized_reference(self, original: str, result: Dict[str, Any]) -> str:
+        """Formatea el resultado de la normalización."""
+        ref_type = result.get('type', 'unknown')
+        norm = result.get('normalized_string', original)
+
+        type_labels = {
+            'law': '📜 Norma legal',
+            'order': '📋 Orden ministerial',
+            'resolution': '📄 Resolución',
+            'boe_issue': '📰 Número del BOE',
+            'unknown': '❓ No reconocido',
+        }
+
+        output = [
+            "# 🔍 Referencia normalizada",
+            "",
+            f"**Texto original:** {original}",
+            f"**Tipo:** {type_labels.get(ref_type, ref_type)}",
+            f"**Forma normalizada:** `{norm}`",
+            "",
+        ]
+
+        if ref_type == 'law':
+            if result.get('law_id'):
+                output.append(f"**Identificador BOE:** `{result['law_id']}`")
+                output.append(
+                    f"💡 Usa `get_law_metadata` o `get_consolidated_law` con el ID `{result['law_id']}` "
+                    "para obtener información completa."
+                )
+            else:
+                if result.get('number') and result.get('year'):
+                    output.append(f"**Número/Año:** {result['number']}/{result['year']}")
+                if result.get('is_organic'):
+                    output.append("**Tipo:** Ley Orgánica")
+                output.append(
+                    "💡 Usa `search_consolidated_legislation` con `query` o `title` para encontrar esta norma."
+                )
+        elif ref_type == 'order':
+            output.append(f"**Departamento (código):** `{result.get('department_code', 'N/A')}`")
+            output.append(f"**Número/Año:** {result.get('number', 'N/A')}/{result.get('year', 'N/A')}")
+            output.append(
+                "💡 Usa `search_consolidated_legislation` con `title` para encontrar esta orden."
+            )
+        elif ref_type == 'boe_issue':
+            if result.get('date'):
+                output.append(f"**Fecha (AAAAMMDD):** `{result['date']}`")
+                output.append(f"💡 Usa `get_boe_summary` con `date: \"{result['date']}\"` para ver el sumario.")
+            if result.get('section'):
+                output.append(f"**Sección:** {result['section']}")
+            if result.get('boe_number'):
+                output.append(f"**Número BOE:** {result['boe_number']}")
+        elif ref_type == 'unknown':
+            output.append(f"⚠️ {result.get('explanation', 'Formato no reconocido.')}")
+            output.append(
+                "💡 Prueba con formatos como: 'Ley 40/2015', 'Real Decreto 123/2020', "
+                "'Orden TED/1234/2023', 'BOE del 3 de mayo de 2024', 'BOE-A-2015-10566'."
+            )
+
+        return "\n".join(output)

--- a/src/mcp_boe/tools/auxiliary.py
+++ b/src/mcp_boe/tools/auxiliary.py
@@ -5,12 +5,14 @@ Este módulo contiene las herramientas que Claude puede usar para consultar
 las tablas de códigos, departamentos, materias y otros datos auxiliares.
 """
 
+import asyncio
 import logging
 from typing import Dict, Any, List, Optional
 
 from mcp.types import TextContent, Tool
 
 from ..utils.http_client import BOEHTTPClient, APIError
+from ..models.boe_models import validate_boe_identifier
 
 logger = logging.getLogger(__name__)
 
@@ -153,7 +155,88 @@ class AuxiliaryTools:
                     "required": ["code"],
                     "additionalProperties": False
                 }
-            )
+            ),
+            # --- Nuevas tools (grupo C) ---
+            Tool(
+                name="search_departments_advanced",
+                description=(
+                    "Búsqueda avanzada de departamentos con filtros adicionales: "
+                    "código padre para explorar jerarquías, filtro de texto y paginación. "
+                    "Complementa a get_departments_table con más opciones de filtrado."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "search_term": {
+                            "type": "string",
+                            "description": "Filtro de texto sobre el nombre del departamento"
+                        },
+                        "active_only": {
+                            "type": "boolean",
+                            "default": True,
+                            "description": "Mostrar solo departamentos activos (default: true)"
+                        },
+                        "parent_code": {
+                            "type": "string",
+                            "description": "Filtrar por prefijo de código para explorar jerarquías (ej: '14' para Ministerio de Justicia y sus organismos)"
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 200,
+                            "default": 50,
+                            "description": "Número máximo de resultados (default: 50)"
+                        }
+                    },
+                    "required": [],
+                    "additionalProperties": False
+                }
+            ),
+            Tool(
+                name="list_topics_for_law",
+                description=(
+                    "Devuelve las materias/temas del vocabulario controlado asociados a una norma. "
+                    "Útil para entender la temática de una ley y encontrar filtros para búsquedas relacionadas."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "law_id": {
+                            "type": "string",
+                            "pattern": "^BOE-[A-Z]-\\d{4}-\\d{1,5}$",
+                            "description": "Identificador único de la norma (ej: 'BOE-A-2015-10566')"
+                        }
+                    },
+                    "required": ["law_id"],
+                    "additionalProperties": False
+                }
+            ),
+            Tool(
+                name="suggest_auxiliary_filters",
+                description=(
+                    "Dado un texto de búsqueda libre, sugiere códigos de departamentos, materias "
+                    "y rangos normativos que podrían usarse como filtros en otras herramientas. "
+                    "Útil para descubrir los códigos correctos antes de una búsqueda de legislación."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Texto libre para el que buscar sugerencias de filtros"
+                        },
+                        "max_suggestions": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 30,
+                            "default": 10,
+                            "description": "Número máximo de sugerencias (default: 10)"
+                        }
+                    },
+                    "required": ["query"],
+                    "additionalProperties": False
+                }
+            ),
         ]
 
     async def get_departments_table(self, arguments: Dict[str, Any]) -> List[TextContent]:
@@ -868,3 +951,346 @@ class AuxiliaryTools:
                 type="text",
                 text=f"Error interno: {str(e)}"
             )]
+
+    # =========================================================================
+    # search_departments_advanced
+    # =========================================================================
+
+    async def search_departments_advanced(self, arguments: Dict[str, Any]) -> List[TextContent]:
+        """Búsqueda avanzada de departamentos con filtros adicionales.
+
+        Extiende get_departments_table con soporte para filtro por código padre
+        (jerarquía de organismos dependientes).
+
+        Args:
+            arguments: Diccionario con search_term, active_only, parent_code y limit.
+
+        Returns:
+            TextContent con la lista de departamentos filtrada.
+        """
+        try:
+            search_term = arguments.get('search_term')
+            active_only = arguments.get('active_only', True)
+            parent_code = arguments.get('parent_code')
+            limit = arguments.get('limit', 50)
+
+            logger.info(
+                f"search_departments_advanced: term={search_term}, "
+                f"parent_code={parent_code}, active_only={active_only}"
+            )
+
+            response = await self.client.get_auxiliary_table('departamentos')
+
+            if not response.get('data'):
+                return [TextContent(type="text", text="No se pudo obtener la tabla de departamentos.")]
+
+            entries = response['data'].get('entradas', [])
+
+            # Filtrar
+            filtered = []
+            for entry in entries:
+                if active_only and not entry.get('activo', True):
+                    continue
+                if search_term and search_term.lower() not in entry.get('descripcion', '').lower():
+                    continue
+                if parent_code:
+                    # Los códigos hijos comienzan por el código padre (convención jerárquica)
+                    if not entry.get('codigo', '').startswith(parent_code):
+                        continue
+                filtered.append(entry)
+
+            filtered.sort(key=lambda e: e.get('descripcion', ''))
+            showing = filtered[:limit]
+
+            formatted = self._format_advanced_departments(showing, filtered, search_term, parent_code, limit)
+            return [TextContent(type="text", text=formatted)]
+
+        except APIError as e:
+            logger.error(f"Error de API en search_departments_advanced: {e}")
+            return [TextContent(type="text", text=f"Error accediendo a departamentos: {e.mensaje}")]
+        except Exception as e:
+            logger.error(f"Error inesperado en search_departments_advanced: {e}")
+            return [TextContent(type="text", text=f"Error interno: {str(e)}")]
+
+    def _format_advanced_departments(
+        self,
+        showing: List[Dict[str, Any]],
+        filtered: List[Dict[str, Any]],
+        search_term: Optional[str],
+        parent_code: Optional[str],
+        limit: int
+    ) -> str:
+        """Formatea los resultados de búsqueda avanzada de departamentos."""
+        output = ["# 🏛️ Departamentos (búsqueda avanzada)", ""]
+
+        if not showing:
+            filters = []
+            if search_term:
+                filters.append(f"texto '{search_term}'")
+            if parent_code:
+                filters.append(f"código padre '{parent_code}'")
+            desc = ' y '.join(filters) if filters else 'los filtros especificados'
+            output.append(f"No se encontraron departamentos para {desc}.")
+            return "\n".join(output)
+
+        output.append(f"**Mostrando {len(showing)} de {len(filtered)} departamentos**")
+        if search_term:
+            output.append(f"*Filtro texto: '{search_term}'*")
+        if parent_code:
+            output.append(f"*Código padre: '{parent_code}'*")
+        output.append("")
+
+        for entry in showing:
+            codigo = entry.get('codigo', 'N/A')
+            desc = entry.get('descripcion', 'Sin descripción')
+            activo = entry.get('activo', True)
+
+            output.append(f"- **{desc}**")
+            output.append(f"  - Código: `{codigo}`")
+            if not activo:
+                output.append("  - ⚠️ *Inactivo*")
+            output.append("")
+
+        if len(filtered) > limit:
+            output.append(f"*(Mostrando los primeros {limit} de {len(filtered)} resultados)*")
+
+        output.append("💡 Usa el código con `search_consolidated_legislation` (department_code) para filtrar normas.")
+        return "\n".join(output)
+
+    # =========================================================================
+    # list_topics_for_law
+    # =========================================================================
+
+    async def list_topics_for_law(self, arguments: Dict[str, Any]) -> List[TextContent]:
+        """Devuelve las materias/temas del vocabulario controlado de una norma.
+
+        Obtiene el análisis de la norma y cruza sus materias con la tabla de materias
+        para enriquecer la información.
+
+        Args:
+            arguments: Diccionario con law_id.
+
+        Returns:
+            TextContent con la lista de materias de la norma.
+        """
+        try:
+            law_id = arguments['law_id']
+
+            if not validate_boe_identifier(law_id):
+                raise ValueError(f"Identificador de norma inválido: {law_id}")
+
+            logger.info(f"Listando materias de norma {law_id}")
+
+            # Obtener análisis de la norma
+            response = await self.client.get_law_by_id(law_id, 'analisis')
+
+            if not response.get('data'):
+                return [TextContent(type="text", text=f"No se encontró análisis para la norma {law_id}.")]
+
+            analysis_data = response['data']
+            materias_norma = analysis_data.get('materias', [])
+
+            if not materias_norma:
+                return [TextContent(
+                    type="text",
+                    text=f"La norma `{law_id}` no tiene materias registradas en el análisis."
+                )]
+
+            # Intentar enriquecer con tabla de materias (best-effort)
+            matters_by_code: Dict[str, str] = {}
+            try:
+                matters_response = await self.client.get_auxiliary_table('materias')
+                if matters_response.get('data'):
+                    for entry in matters_response['data'].get('entradas', []):
+                        matters_by_code[entry.get('codigo', '')] = entry.get('descripcion', '')
+            except APIError:
+                pass  # La tabla es opcional
+
+            formatted = self._format_law_topics(materias_norma, law_id, matters_by_code)
+            return [TextContent(type="text", text=formatted)]
+
+        except APIError as e:
+            logger.error(f"Error de API en list_topics_for_law: {e}")
+            return [TextContent(type="text", text=f"Error accediendo a la norma {law_id}: {e.mensaje}")]
+        except Exception as e:
+            logger.error(f"Error inesperado en list_topics_for_law: {e}")
+            return [TextContent(type="text", text=f"Error interno: {str(e)}")]
+
+    def _format_law_topics(
+        self,
+        materias: List[Any],
+        law_id: str,
+        matters_by_code: Dict[str, str]
+    ) -> str:
+        """Formatea las materias de una norma."""
+        output = [f"# 📚 Materias de la norma `{law_id}`", ""]
+
+        output.append(f"**{len(materias)} materia(s) registrada(s):**")
+        output.append("")
+
+        for materia in materias:
+            if isinstance(materia, dict):
+                codigo = materia.get('codigo', 'N/A')
+                texto = materia.get('texto', '')
+                # Enriquecer si tenemos la tabla
+                tabla_desc = matters_by_code.get(codigo, '')
+                desc = texto or tabla_desc or 'Sin descripción'
+                output.append(f"- **{desc}** (`{codigo}`)")
+            else:
+                output.append(f"- {materia}")
+
+        output.append("")
+        output.append(
+            "💡 Usa estos códigos con `search_consolidated_legislation` (matter_code) "
+            "para encontrar otras normas sobre los mismos temas."
+        )
+        return "\n".join(output)
+
+    # =========================================================================
+    # suggest_auxiliary_filters
+    # =========================================================================
+
+    async def suggest_auxiliary_filters(self, arguments: Dict[str, Any]) -> List[TextContent]:
+        """Dado un texto libre, sugiere códigos de tablas auxiliares como filtros.
+
+        Carga departamentos, rangos y materias en paralelo y realiza una búsqueda
+        case-insensitive sobre las descripciones.
+
+        Args:
+            arguments: Diccionario con query y max_suggestions.
+
+        Returns:
+            TextContent con las sugerencias de filtros ordenadas por relevancia.
+        """
+        try:
+            query = arguments['query']
+            max_suggestions = arguments.get('max_suggestions', 10)
+
+            if not query.strip():
+                raise ValueError("El parámetro 'query' no puede estar vacío.")
+
+            logger.info(f"suggest_auxiliary_filters: query='{query}', max={max_suggestions}")
+
+            # Cargar tablas en paralelo
+            table_names = ['departamentos', 'rangos', 'materias']
+            type_labels = {
+                'departamentos': 'department',
+                'rangos': 'range',
+                'materias': 'topic',
+            }
+
+            results = await asyncio.gather(
+                *[self.client.get_auxiliary_table(t) for t in table_names],
+                return_exceptions=True
+            )
+
+            suggestions: List[Dict[str, Any]] = []
+            query_lower = query.lower()
+
+            for table_name, result in zip(table_names, results):
+                if isinstance(result, Exception):
+                    continue
+                if not result.get('data'):
+                    continue
+
+                table_type = type_labels[table_name]
+                for entry in result['data'].get('entradas', []):
+                    desc = entry.get('descripcion', '')
+                    codigo = entry.get('codigo', '')
+                    if not entry.get('activo', True):
+                        continue
+
+                    if query_lower in desc.lower() or query_lower in codigo.lower():
+                        # Calcular relevancia: coincidencia al inicio > en medio
+                        pos = desc.lower().find(query_lower)
+                        relevance = 0 if pos == 0 else (1 if pos > 0 else 2)
+                        suggestions.append({
+                            'type': table_type,
+                            'code': codigo,
+                            'label': desc,
+                            '_relevance': relevance,
+                            '_pos': pos,
+                        })
+
+            # Ordenar por relevancia y posición de la coincidencia
+            suggestions.sort(key=lambda s: (s['_relevance'], s['_pos']))
+
+            # Limitar y limpiar
+            showing = suggestions[:max_suggestions]
+            for s in showing:
+                s.pop('_relevance', None)
+                s.pop('_pos', None)
+
+            formatted = self._format_filter_suggestions(showing, query, max_suggestions, len(suggestions))
+            return [TextContent(type="text", text=formatted)]
+
+        except ValueError as e:
+            return [TextContent(type="text", text=f"Parámetros inválidos: {str(e)}")]
+        except Exception as e:
+            logger.error(f"Error en suggest_auxiliary_filters: {e}")
+            return [TextContent(type="text", text=f"Error interno: {str(e)}")]
+
+    def _format_filter_suggestions(
+        self,
+        suggestions: List[Dict[str, Any]],
+        query: str,
+        max_suggestions: int,
+        total_found: int
+    ) -> str:
+        """Formatea las sugerencias de filtros."""
+        output = [
+            f"# 💡 Sugerencias de filtros para «{query}»",
+            "",
+        ]
+
+        if not suggestions:
+            output.append(
+                f"No se encontraron filtros de tablas auxiliares relacionados con «{query}».\n\n"
+                "Prueba con términos más generales o consulta directamente "
+                "`get_departments_table`, `get_legal_ranges_table` o `get_matters_table`."
+            )
+            return "\n".join(output)
+
+        type_emojis = {
+            'department': '🏛️ Departamento',
+            'range': '⚖️ Rango normativo',
+            'topic': '📚 Materia',
+        }
+
+        output.append(
+            f"**{len(suggestions)} sugerencia(s)**"
+            + (f" de {total_found} encontradas" if total_found > max_suggestions else "")
+        )
+        output.append("")
+
+        # Agrupar por tipo para mejor legibilidad
+        by_type: Dict[str, List[Dict]] = {}
+        for s in suggestions:
+            by_type.setdefault(s['type'], []).append(s)
+
+        for type_key, type_label in type_emojis.items():
+            items = by_type.get(type_key, [])
+            if not items:
+                continue
+            output.append(f"## {type_label}")
+            output.append("")
+            for item in items:
+                output.append(f"- **{item['label']}** — código: `{item['code']}`")
+            output.append("")
+
+        # Pista de uso
+        param_map = {
+            'department': 'department_code',
+            'range': 'legal_range_code',
+            'topic': 'matter_code',
+        }
+        output.append("## Cómo usar estos filtros")
+        output.append("")
+        output.append("Pasa los códigos como parámetros en `search_consolidated_legislation`:")
+        output.append("```")
+        for s in suggestions[:3]:
+            param = param_map.get(s['type'], 'code')
+            output.append(f'{param}: "{s["code"]}"  # {s["label"]}')
+        output.append("```")
+
+        return "\n".join(output)

--- a/src/mcp_boe/tools/documents.py
+++ b/src/mcp_boe/tools/documents.py
@@ -29,10 +29,15 @@ class DocumentTools:
             Tool(
                 name="read_boe_pdf",
                 description=(
-                    "Descarga y extrae el texto de un PDF del BOE para que puedas "
-                    "leerlo y explicar de qué trata. Acepta la URL directa del PDF "
-                    "(campo url_pdf de los sumarios) o el identificador BOE "
-                    "(ej: BOE-A-2025-6192), del que se construye la URL automáticamente."
+                    "Descarga y extrae el texto COMPLETO de cualquier documento del BOE "
+                    "(leyes, decretos, órdenes ministeriales, ceses, nombramientos, "
+                    "anuncios, resoluciones, etc.) para leerlo y explicarlo en detalle. "
+                    "Úsala SIEMPRE que el usuario pida 'más detalles', 'el contenido', "
+                    "'qué dice exactamente' o 'léeme' un documento del BOE. "
+                    "Acepta la URL directa del PDF (campo url_pdf de los sumarios) "
+                    "o el identificador BOE (ej: BOE-A-2025-6192), del que se construye "
+                    "la URL automáticamente. Es la única herramienta que puede leer el "
+                    "contenido íntegro de documentos NO consolidados (sección II, III, etc.)."
                 ),
                 inputSchema={
                     "type": "object",
@@ -121,7 +126,7 @@ class DocumentTools:
 
         diario = parts[0].lower()   # "boe" o "borme"
 
-        # Consultamos la API de metadatos para obtener la fecha real de publicación
+        # Intento 1: API de legislación consolidada (devuelve fecha en YYYYMMDD o YYYY-MM-DD)
         try:
             api_url = f"https://www.boe.es/datosabiertos/api/legislacion-consolidada/id/{boe_id}/metadatos"
             async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
@@ -129,16 +134,43 @@ class DocumentTools:
                 if r.status_code == 200:
                     payload = r.json()
                     data = payload.get("data") or {}
-                    # La API puede devolver data como lista o como dict
                     if isinstance(data, list):
                         data = data[0] if data else {}
-                    fecha = data.get("fecha_publicacion", "")
-                    if fecha and len(fecha) == 8:
+                    fecha = self._normalize_fecha(data.get("fecha_publicacion", ""))
+                    if fecha:
                         yyyy, mm, dd = fecha[:4], fecha[4:6], fecha[6:]
                         return f"https://www.boe.es/{diario}/dias/{yyyy}/{mm}/{dd}/pdfs/{boe_id}.pdf"
         except Exception:
             pass
 
+        # Intento 2: página HTML del BOE, que existe para CUALQUIER documento publicado
+        try:
+            import re
+            html_url = f"https://www.boe.es/diario_boe/txt.php?id={boe_id}"
+            async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
+                r = await client.get(html_url, headers={"Accept": "text/html"})
+                if r.status_code == 200:
+                    match = re.search(
+                        r'/(?:boe|borme)/dias/(\d{4}/\d{2}/\d{2})/pdfs/',
+                        r.text,
+                    )
+                    if match:
+                        date_path = match.group(1)   # "2026/04/29"
+                        return f"https://www.boe.es/{diario}/dias/{date_path}/pdfs/{boe_id}.pdf"
+        except Exception:
+            pass
+
+        return None
+
+    @staticmethod
+    def _normalize_fecha(fecha: str) -> str | None:
+        """Normaliza fecha a formato YYYYMMDD; acepta YYYYMMDD y YYYY-MM-DD."""
+        if not fecha:
+            return None
+        if len(fecha) == 8 and fecha.isdigit():
+            return fecha
+        if len(fecha) == 10 and fecha[4] == "-" and fecha[7] == "-":
+            return fecha.replace("-", "")
         return None
 
     async def _download_pdf(self, url: str) -> bytes:

--- a/src/mcp_boe/tools/legislation.py
+++ b/src/mcp_boe/tools/legislation.py
@@ -24,6 +24,9 @@ from ..models.boe_models import (
 
 logger = logging.getLogger(__name__)
 
+# Tipos de bloque que se consideran artículos para compare/search
+_ARTICLE_TIPOS = frozenset({'precepto', 'parte_dispositiva'})
+
 
 class LegislationTools:
     """Herramientas para trabajar con legislación consolidada."""
@@ -186,7 +189,134 @@ class LegislationTools:
                     "required": ["law_id"],
                     "additionalProperties": False
                 }
-            )
+            ),
+            # --- Nuevas tools (grupo A) ---
+            Tool(
+                name="compare_law_versions",
+                description=(
+                    "Compara el texto de una norma entre dos fechas de consolidación distintas, "
+                    "detectando artículos añadidos, modificados o eliminados. "
+                    "Útil para entender qué cambió en una norma a lo largo del tiempo."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "law_id": {
+                            "type": "string",
+                            "pattern": "^BOE-[A-Z]-\\d{4}-\\d{1,5}$",
+                            "description": "Identificador único de la norma (ej: 'BOE-A-2015-10566')"
+                        },
+                        "from_date": {
+                            "type": "string",
+                            "description": "Fecha inicial en formato AAAAMMDD o YYYY-MM-DD (ej: '20200101')"
+                        },
+                        "to_date": {
+                            "type": "string",
+                            "description": "Fecha final en formato AAAAMMDD o YYYY-MM-DD (ej: '20230101')"
+                        },
+                        "granularity": {
+                            "type": "string",
+                            "enum": ["articulo", "capitulo", "titulo"],
+                            "default": "articulo",
+                            "description": "Nivel al que detectar cambios (default: articulo)"
+                        }
+                    },
+                    "required": ["law_id", "from_date", "to_date"],
+                    "additionalProperties": False
+                }
+            ),
+            Tool(
+                name="search_law_articles",
+                description=(
+                    "Busca artículos concretos dentro de una norma que contengan un texto dado, "
+                    "sin necesidad de devolver la norma entera. "
+                    "Devuelve únicamente los artículos que coinciden, con un fragmento del texto relevante."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "law_id": {
+                            "type": "string",
+                            "pattern": "^BOE-[A-Z]-\\d{4}-\\d{1,5}$",
+                            "description": "Identificador único de la norma"
+                        },
+                        "query": {
+                            "type": "string",
+                            "description": "Texto a buscar dentro de los artículos"
+                        },
+                        "search_in": {
+                            "type": "string",
+                            "enum": ["titulo", "texto", "ambos"],
+                            "default": "ambos",
+                            "description": "Dónde buscar: solo en el título del artículo, solo en el texto, o en ambos"
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "default": 20,
+                            "description": "Número máximo de artículos a devolver"
+                        }
+                    },
+                    "required": ["law_id", "query"],
+                    "additionalProperties": False
+                }
+            ),
+            Tool(
+                name="get_law_metadata",
+                description=(
+                    "Obtiene únicamente los metadatos de una norma (rango, fecha, órgano, estado, "
+                    "enlaces) sin cargar el texto completo. Más rápido que get_consolidated_law "
+                    "cuando solo se necesita información descriptiva."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "law_id": {
+                            "type": "string",
+                            "pattern": "^BOE-[A-Z]-\\d{4}-\\d{1,5}$",
+                            "description": "Identificador único de la norma (ej: 'BOE-A-2015-10566')"
+                        }
+                    },
+                    "required": ["law_id"],
+                    "additionalProperties": False
+                }
+            ),
+            Tool(
+                name="list_related_laws",
+                description=(
+                    "Lista las normas relacionadas con una dada, con control granular sobre "
+                    "qué tipos de relaciones incluir (derogaciones, desarrollo reglamentario, "
+                    "referencias genéricas). Complementa a find_related_laws con más opciones de filtrado."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "law_id": {
+                            "type": "string",
+                            "pattern": "^BOE-[A-Z]-\\d{4}-\\d{1,5}$",
+                            "description": "Identificador único de la norma base"
+                        },
+                        "include_derogating": {
+                            "type": "boolean",
+                            "default": True,
+                            "description": "Incluir relaciones de derogación"
+                        },
+                        "include_development": {
+                            "type": "boolean",
+                            "default": True,
+                            "description": "Incluir relaciones de desarrollo reglamentario"
+                        },
+                        "include_references": {
+                            "type": "boolean",
+                            "default": True,
+                            "description": "Incluir otras referencias"
+                        }
+                    },
+                    "required": ["law_id"],
+                    "additionalProperties": False
+                }
+            ),
         ]
 
     async def search_consolidated_legislation(self, arguments: Dict[str, Any]) -> List[TextContent]:
@@ -1073,5 +1203,513 @@ class LegislationTools:
 
         output.append("---")
         output.append("💡 Use `get_consolidated_law` con cualquiera de los IDs mostrados para obtener más información sobre esas normas.")
-        
+
+        return "\n".join(output)
+
+    # =========================================================================
+    # compare_law_versions
+    # =========================================================================
+
+    async def compare_law_versions(self, arguments: Dict[str, Any]) -> List[TextContent]:
+        """Compara el texto de una norma entre dos fechas de consolidación.
+
+        Usa el historial de versiones de cada TextBlock para reconstruir el texto
+        vigente en cada fecha y detectar diferencias.
+
+        Args:
+            arguments: Diccionario con law_id, from_date, to_date y granularity.
+
+        Returns:
+            TextContent con los cambios detectados en formato markdown.
+        """
+        try:
+            law_id = arguments['law_id']
+            from_date_raw = arguments['from_date']
+            to_date_raw = arguments['to_date']
+            granularity = arguments.get('granularity', 'articulo')
+
+            if not validate_boe_identifier(law_id):
+                raise ValueError(f"Identificador de norma inválido: {law_id}")
+
+            from_date = format_date_for_api(from_date_raw)
+            to_date = format_date_for_api(to_date_raw)
+
+            if from_date >= to_date:
+                raise ValueError(f"from_date ({from_date}) debe ser anterior a to_date ({to_date})")
+
+            logger.info(f"Comparando versiones de {law_id}: {from_date} → {to_date}, granularidad={granularity}")
+
+            response = await self.client.get_law_by_id(law_id, 'texto')
+
+            if not response.get('data'):
+                return [TextContent(
+                    type="text",
+                    text=f"No se encontró texto para la norma {law_id}."
+                )]
+
+            bloques = response['data'].get('texto', [])
+            if not isinstance(bloques, list):
+                bloques = [bloques] if bloques else []
+
+            changes = self._detect_version_changes(bloques, from_date, to_date, granularity)
+            formatted = self._format_version_comparison(changes, law_id, from_date_raw, to_date_raw)
+            return [TextContent(type="text", text=formatted)]
+
+        except APIError as e:
+            logger.error(f"Error de API comparando versiones de {law_id}: {e}")
+            return [TextContent(type="text", text=f"Error accediendo a la norma {law_id}: {e.mensaje}")]
+        except Exception as e:
+            logger.error(f"Error inesperado comparando versiones: {e}")
+            return [TextContent(type="text", text=f"Error interno: {str(e)}")]
+
+    def _get_active_version(self, versiones: List[Dict[str, Any]], target_date: str) -> Optional[Dict[str, Any]]:
+        """Devuelve la versión activa de un bloque en una fecha dada.
+
+        La versión activa es la de mayor fecha_vigencia que sea <= target_date.
+        """
+        candidates = []
+        for v in versiones:
+            fv = v.get('fecha_vigencia') or v.get('fecha_publicacion', '')
+            if fv and fv <= target_date:
+                candidates.append((fv, v))
+        if not candidates:
+            return None
+        # La más reciente que no supera target_date
+        candidates.sort(key=lambda x: x[0], reverse=True)
+        return candidates[0][1]
+
+    def _detect_version_changes(
+        self,
+        bloques: List[Dict[str, Any]],
+        from_date: str,
+        to_date: str,
+        granularity: str
+    ) -> List[Dict[str, Any]]:
+        """Detecta cambios en los bloques entre dos fechas."""
+        changes = []
+
+        for bloque in bloques:
+            tipo = bloque.get('tipo', '')
+            block_id = bloque.get('id', 'N/A')
+            titulo = bloque.get('titulo', 'Sin título')
+
+            # Filtrar según granularidad
+            if granularity == 'articulo' and tipo not in _ARTICLE_TIPOS:
+                continue
+
+            versiones = bloque.get('versiones', [])
+            if not isinstance(versiones, list):
+                versiones = [versiones] if versiones else []
+
+            v_from = self._get_active_version(versiones, from_date)
+            v_to = self._get_active_version(versiones, to_date)
+
+            old_text = self._clean_html_content(v_from.get('contenido_html', '')) if v_from else None
+            new_text = self._clean_html_content(v_to.get('contenido_html', '')) if v_to else None
+
+            if v_from is None and v_to is not None:
+                changes.append({
+                    'unit_type': tipo,
+                    'unit_id': block_id,
+                    'unit_title': titulo,
+                    'change_type': 'added',
+                    'old_text': None,
+                    'new_text': new_text,
+                })
+            elif v_from is not None and v_to is None:
+                changes.append({
+                    'unit_type': tipo,
+                    'unit_id': block_id,
+                    'unit_title': titulo,
+                    'change_type': 'removed',
+                    'old_text': old_text,
+                    'new_text': None,
+                })
+            elif v_from and v_to:
+                old_html = v_from.get('contenido_html', '')
+                new_html = v_to.get('contenido_html', '')
+                # Detectar cambio real: comparar norma modificadora o contenido
+                id_from = v_from.get('id_norma', '')
+                id_to = v_to.get('id_norma', '')
+                if id_from != id_to or old_html != new_html:
+                    changes.append({
+                        'unit_type': tipo,
+                        'unit_id': block_id,
+                        'unit_title': titulo,
+                        'change_type': 'modified',
+                        'old_text': old_text,
+                        'new_text': new_text,
+                    })
+
+        return changes
+
+    def _format_version_comparison(
+        self,
+        changes: List[Dict[str, Any]],
+        law_id: str,
+        from_date: str,
+        to_date: str
+    ) -> str:
+        """Formatea el resultado de la comparación de versiones."""
+        output = [
+            f"# 🔄 Comparación de versiones: `{law_id}`",
+            f"**Desde:** {from_date} → **Hasta:** {to_date}",
+            "",
+        ]
+
+        if not changes:
+            output.append("✅ **Sin cambios detectados** entre las dos fechas para los bloques analizados.")
+            output.append("")
+            output.append(
+                "Nota: esto puede ocurrir si la norma no fue modificada entre esas fechas, "
+                "o si ninguna versión con esas fechas de vigencia está disponible en el BOE."
+            )
+            return "\n".join(output)
+
+        added = [c for c in changes if c['change_type'] == 'added']
+        modified = [c for c in changes if c['change_type'] == 'modified']
+        removed = [c for c in changes if c['change_type'] == 'removed']
+
+        output.append(
+            f"**Resumen:** {len(added)} añadidos · {len(modified)} modificados · {len(removed)} eliminados"
+        )
+        output.append("")
+
+        if added:
+            output.append("## ✅ Bloques añadidos")
+            for c in added:
+                output.append(f"### `{c['unit_id']}` — {c['unit_title']}")
+                if c['new_text']:
+                    snippet = c['new_text'][:300] + ('…' if len(c['new_text']) > 300 else '')
+                    output.append(f"> {snippet}")
+                output.append("")
+
+        if modified:
+            output.append("## ✏️ Bloques modificados")
+            for c in modified:
+                output.append(f"### `{c['unit_id']}` — {c['unit_title']}")
+                if c['old_text']:
+                    old_snippet = c['old_text'][:200] + ('…' if len(c['old_text']) > 200 else '')
+                    output.append(f"**Antes:** {old_snippet}")
+                if c['new_text']:
+                    new_snippet = c['new_text'][:200] + ('…' if len(c['new_text']) > 200 else '')
+                    output.append(f"**Después:** {new_snippet}")
+                output.append("")
+
+        if removed:
+            output.append("## ❌ Bloques eliminados")
+            for c in removed:
+                output.append(f"### `{c['unit_id']}` — {c['unit_title']}")
+                if c['old_text']:
+                    snippet = c['old_text'][:300] + ('…' if len(c['old_text']) > 300 else '')
+                    output.append(f"> {snippet}")
+                output.append("")
+
+        output.append("---")
+        output.append(
+            "💡 Usa `get_law_text_block` con cualquiera de los IDs anteriores para leer el bloque completo."
+        )
+        return "\n".join(output)
+
+    # =========================================================================
+    # search_law_articles
+    # =========================================================================
+
+    async def search_law_articles(self, arguments: Dict[str, Any]) -> List[TextContent]:
+        """Busca artículos dentro de una norma que contengan un texto dado.
+
+        Args:
+            arguments: Diccionario con law_id, query, search_in y limit.
+
+        Returns:
+            TextContent con los artículos que coinciden y sus fragmentos relevantes.
+        """
+        try:
+            law_id = arguments['law_id']
+            query = arguments['query']
+            search_in = arguments.get('search_in', 'ambos')
+            limit = arguments.get('limit', 20)
+
+            if not validate_boe_identifier(law_id):
+                raise ValueError(f"Identificador de norma inválido: {law_id}")
+            if not query.strip():
+                raise ValueError("El parámetro 'query' no puede estar vacío.")
+
+            logger.info(f"Buscando '{query}' en artículos de {law_id}, search_in={search_in}")
+
+            response = await self.client.get_law_by_id(law_id, 'texto')
+
+            if not response.get('data'):
+                return [TextContent(type="text", text=f"No se encontró texto para la norma {law_id}.")]
+
+            bloques = response['data'].get('texto', [])
+            if not isinstance(bloques, list):
+                bloques = [bloques] if bloques else []
+
+            matches = self._search_in_blocks(bloques, query, search_in, limit)
+            formatted = self._format_article_search(matches, law_id, query)
+            return [TextContent(type="text", text=formatted)]
+
+        except APIError as e:
+            logger.error(f"Error de API buscando en artículos de {law_id}: {e}")
+            return [TextContent(type="text", text=f"Error accediendo a la norma {law_id}: {e.mensaje}")]
+        except Exception as e:
+            logger.error(f"Error inesperado buscando artículos: {e}")
+            return [TextContent(type="text", text=f"Error interno: {str(e)}")]
+
+    def _search_in_blocks(
+        self,
+        bloques: List[Dict[str, Any]],
+        query: str,
+        search_in: str,
+        limit: int
+    ) -> List[Dict[str, Any]]:
+        """Busca el query en los bloques de tipo precepto."""
+        query_lower = query.lower()
+        matches = []
+
+        for bloque in bloques:
+            if bloque.get('tipo') not in _ARTICLE_TIPOS:
+                continue
+
+            block_id = bloque.get('id', 'N/A')
+            titulo = bloque.get('titulo', '')
+
+            versiones = bloque.get('versiones', [])
+            if not isinstance(versiones, list):
+                versiones = [versiones] if versiones else []
+
+            html = versiones[0].get('contenido_html', '') if versiones else ''
+            plain_text = self._clean_html_content(html)
+
+            found_in_title = (search_in in ('titulo', 'ambos')) and query_lower in titulo.lower()
+            found_in_text = (search_in in ('texto', 'ambos')) and query_lower in plain_text.lower()
+
+            if not (found_in_title or found_in_text):
+                continue
+
+            # Construir snippet con contexto
+            snippet = self._build_snippet(plain_text, query_lower)
+
+            matches.append({
+                'article_id': block_id,
+                'title': titulo,
+                'snippet': snippet,
+                'full_text': plain_text if len(plain_text) <= 500 else None,
+            })
+
+            if len(matches) >= limit:
+                break
+
+        return matches
+
+    def _build_snippet(self, text: str, query_lower: str, context: int = 100) -> str:
+        """Construye un fragmento de texto alrededor de la primera coincidencia."""
+        pos = text.lower().find(query_lower)
+        if pos < 0:
+            return text[:200] + ('…' if len(text) > 200 else '')
+
+        start = max(0, pos - context)
+        end = min(len(text), pos + len(query_lower) + context)
+        snippet = text[start:end]
+        if start > 0:
+            snippet = '…' + snippet
+        if end < len(text):
+            snippet += '…'
+        return snippet
+
+    def _format_article_search(
+        self,
+        matches: List[Dict[str, Any]],
+        law_id: str,
+        query: str
+    ) -> str:
+        """Formatea los resultados de búsqueda de artículos."""
+        output = [
+            f"# 🔍 Búsqueda en artículos de `{law_id}`",
+            f"**Query:** «{query}»",
+            "",
+        ]
+
+        if not matches:
+            output.append(f"No se encontraron artículos que contengan «{query}» en esta norma.")
+            return "\n".join(output)
+
+        output.append(f"**{len(matches)} artículo(s) encontrado(s):**")
+        output.append("")
+
+        for m in matches:
+            output.append(f"### `{m['article_id']}` — {m['title']}")
+            output.append(f"> {m['snippet']}")
+            output.append("")
+
+        output.append("---")
+        output.append("💡 Usa `get_law_text_block` con cualquiera de los IDs para leer el artículo completo.")
+        return "\n".join(output)
+
+    # =========================================================================
+    # get_law_metadata
+    # =========================================================================
+
+    async def get_law_metadata(self, arguments: Dict[str, Any]) -> List[TextContent]:
+        """Obtiene únicamente los metadatos de una norma, sin cargar el texto.
+
+        Args:
+            arguments: Diccionario con law_id.
+
+        Returns:
+            TextContent con los metadatos estructurados.
+        """
+        try:
+            law_id = arguments['law_id']
+
+            if not validate_boe_identifier(law_id):
+                raise ValueError(f"Identificador de norma inválido: {law_id}")
+
+            logger.info(f"Obteniendo metadatos de norma {law_id}")
+
+            response = await self.client.get_law_by_id(law_id, 'metadatos')
+
+            if not response.get('data'):
+                return [TextContent(type="text", text=f"No se encontraron metadatos para la norma {law_id}.")]
+
+            formatted = self._format_law_metadata(response['data'])
+            return [TextContent(type="text", text=formatted)]
+
+        except APIError as e:
+            logger.error(f"Error de API obteniendo metadatos de {law_id}: {e}")
+            return [TextContent(type="text", text=f"Error accediendo a la norma {law_id}: {e.mensaje}")]
+        except Exception as e:
+            logger.error(f"Error inesperado obteniendo metadatos: {e}")
+            return [TextContent(type="text", text=f"Error interno: {str(e)}")]
+
+    # =========================================================================
+    # list_related_laws
+    # =========================================================================
+
+    async def list_related_laws(self, arguments: Dict[str, Any]) -> List[TextContent]:
+        """Lista normas relacionadas con control granular sobre los tipos de relación.
+
+        A diferencia de find_related_laws (que filtra por tipo único), esta tool
+        acepta flags booleanos para cada categoría de relación.
+
+        Args:
+            arguments: Diccionario con law_id y flags include_*.
+
+        Returns:
+            TextContent con las relaciones agrupadas por categoría.
+        """
+        try:
+            law_id = arguments['law_id']
+            include_derogating = arguments.get('include_derogating', True)
+            include_development = arguments.get('include_development', True)
+            include_references = arguments.get('include_references', True)
+
+            if not validate_boe_identifier(law_id):
+                raise ValueError(f"Identificador de norma inválido: {law_id}")
+
+            logger.info(
+                f"Listando normas relacionadas con {law_id}: "
+                f"derogating={include_derogating}, development={include_development}, "
+                f"references={include_references}"
+            )
+
+            response = await self.client.get_law_by_id(law_id, 'analisis')
+
+            if not response.get('data'):
+                return [TextContent(type="text", text=f"No se encontró análisis para la norma {law_id}.")]
+
+            analysis_data = response['data']
+            formatted = self._format_related_laws(
+                analysis_data, law_id,
+                include_derogating, include_development, include_references
+            )
+            return [TextContent(type="text", text=formatted)]
+
+        except APIError as e:
+            logger.error(f"Error de API listando relaciones de {law_id}: {e}")
+            return [TextContent(type="text", text=f"Error accediendo a la norma {law_id}: {e.mensaje}")]
+        except Exception as e:
+            logger.error(f"Error inesperado listando relaciones: {e}")
+            return [TextContent(type="text", text=f"Error interno: {str(e)}")]
+
+    def _classify_relation(self, rel_text: str) -> str:
+        """Clasifica una relación en derogating, development o reference."""
+        upper = rel_text.upper()
+        if any(kw in upper for kw in ('DEROGA', 'ANULA', 'SUPRIME')):
+            return 'derogating'
+        if any(kw in upper for kw in ('DESARROLLA', 'COMPLEMENTA', 'EJECUTA', 'APLICA')):
+            return 'development'
+        return 'reference'
+
+    def _format_related_laws(
+        self,
+        analysis_data: Dict[str, Any],
+        law_id: str,
+        include_derogating: bool,
+        include_development: bool,
+        include_references: bool
+    ) -> str:
+        """Formatea las relaciones de la norma agrupadas por categoría."""
+        output = [f"# 🔗 Normas relacionadas con `{law_id}`", ""]
+
+        referencias = analysis_data.get('referencias', {})
+        anteriores = referencias.get('anteriores', [])
+        posteriores = referencias.get('posteriores', [])
+
+        all_refs = [
+            {'dir': 'anterior', **ref} for ref in anteriores
+        ] + [
+            {'dir': 'posterior', **ref} for ref in posteriores
+        ]
+
+        if not all_refs:
+            output.append(f"No se encontraron normas relacionadas con `{law_id}`.")
+            return "\n".join(output)
+
+        # Clasificar
+        groups: Dict[str, List[Dict]] = {'derogating': [], 'development': [], 'reference': []}
+        for ref in all_refs:
+            relacion = ref.get('relacion', {})
+            rel_text = relacion.get('texto', '') if isinstance(relacion, dict) else str(relacion)
+            cat = self._classify_relation(rel_text)
+            groups[cat].append(ref)
+
+        total_shown = 0
+
+        def _render_group(label: str, refs: List[Dict]) -> None:
+            nonlocal total_shown
+            if not refs:
+                return
+            output.append(f"## {label} ({len(refs)})")
+            output.append("")
+            for ref in refs:
+                id_norma = ref.get('id_norma', 'N/A')
+                relacion = ref.get('relacion', {})
+                rel_text = relacion.get('texto', 'Relacionada') if isinstance(relacion, dict) else str(relacion)
+                desc = ref.get('texto', '')
+                dir_arrow = "← afecta a esta norma" if ref.get('dir') == 'posterior' else "→ afecta a norma anterior"
+                output.append(f"- **`{id_norma}`** — {rel_text}")
+                if desc:
+                    output.append(f"  - {desc}")
+                output.append(f"  - *{dir_arrow}*")
+                output.append("")
+                total_shown += 1
+
+        if include_derogating:
+            _render_group("🚫 Derogación / Anulación", groups['derogating'])
+        if include_development:
+            _render_group("📋 Desarrollo reglamentario", groups['development'])
+        if include_references:
+            _render_group("🔗 Otras referencias", groups['reference'])
+
+        if total_shown == 0:
+            output.append("No se encontraron relaciones para los filtros seleccionados.")
+        else:
+            output.append("---")
+            output.append(
+                f"**Total:** {total_shown} relación(es) mostrada(s). "
+                "Usa `get_consolidated_law` con cualquier ID para obtener más detalles."
+            )
+
         return "\n".join(output)

--- a/src/mcp_boe/tools/summaries.py
+++ b/src/mcp_boe/tools/summaries.py
@@ -133,7 +133,7 @@ class SummaryTools:
                 name="get_weekly_summary",
                 description="Obtiene un resumen semanal de publicaciones del BOE",
                 inputSchema={
-                    "type": "object", 
+                    "type": "object",
                     "properties": {
                         "start_date": {
                             "type": "string",
@@ -149,7 +149,111 @@ class SummaryTools:
                     "required": ["start_date"],
                     "additionalProperties": False
                 }
-            )
+            ),
+            # --- Nuevas tools (grupo B) ---
+            Tool(
+                name="get_boe_summary_range",
+                description=(
+                    "Obtiene y agrega los sumarios del BOE para un rango de fechas. "
+                    "Permite ver todas las publicaciones de un período sin llamar a get_boe_summary "
+                    "día por día. Máximo 31 días de rango."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "from_date": {
+                            "type": "string",
+                            "description": "Fecha de inicio en formato AAAAMMDD o YYYY-MM-DD"
+                        },
+                        "to_date": {
+                            "type": "string",
+                            "description": "Fecha de fin en formato AAAAMMDD o YYYY-MM-DD"
+                        },
+                        "section": {
+                            "type": "string",
+                            "description": "Filtrar por sección del BOE (ej: '1', '2A', '3'). Omitir para todas."
+                        },
+                        "max_items": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 500,
+                            "default": 100,
+                            "description": "Límite total de documentos a devolver (default: 100)"
+                        }
+                    },
+                    "required": ["from_date", "to_date"],
+                    "additionalProperties": False
+                }
+            ),
+            Tool(
+                name="watch_boe_changes",
+                description=(
+                    "Busca publicaciones recientes del BOE que coincidan con palabras clave, "
+                    "mirando hacia atrás un número de días configurable. "
+                    "Útil como 'radar normativo' para monitorizar temas de interés."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "days_back": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 90,
+                            "description": "Número de días hacia atrás para buscar"
+                        },
+                        "keywords": {
+                            "type": "string",
+                            "description": "Palabras clave separadas por espacios. Se busca cada palabra de forma independiente (OR)."
+                        },
+                        "sections": {
+                            "type": "string",
+                            "description": "Secciones del BOE a incluir, separadas por comas (ej: '1,3'). Omitir para todas."
+                        },
+                        "max_items": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 200,
+                            "default": 50,
+                            "description": "Límite total de resultados (default: 50)"
+                        }
+                    },
+                    "required": ["days_back", "keywords"],
+                    "additionalProperties": False
+                }
+            ),
+            Tool(
+                name="group_summary_by_department",
+                description=(
+                    "Obtiene el sumario del BOE para un rango de fechas y agrupa las publicaciones "
+                    "por departamento emisor, mostrando cuántas y cuáles disposiciones emitió cada uno."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "from_date": {
+                            "type": "string",
+                            "description": "Fecha de inicio en formato AAAAMMDD o YYYY-MM-DD"
+                        },
+                        "to_date": {
+                            "type": "string",
+                            "description": "Fecha de fin en formato AAAAMMDD o YYYY-MM-DD"
+                        },
+                        "sections": {
+                            "type": "string",
+                            "description": "Secciones del BOE a incluir, separadas por comas. Omitir para todas."
+                        },
+                        "max_items_per_dept": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "default": 10,
+                            "description": "Máximo de documentos a mostrar por departamento (default: 10)"
+                        }
+                    },
+                    "required": ["from_date", "to_date"],
+                    "additionalProperties": False
+                }
+            ),
         ]
 
     async def get_boe_summary(self, arguments: Dict[str, Any]) -> List[TextContent]:
@@ -933,4 +1037,407 @@ class SummaryTools:
                 text=f"Error accediendo al sumario del BORME: {e.mensaje}"
             )]
         except Exception as e:
-            logger
+            logger.error(f"Error inesperado obteniendo sumario BORME: {e}")
+            return [TextContent(
+                type="text",
+                text=f"Error interno: {str(e)}"
+            )]
+
+    # =========================================================================
+    # get_boe_summary_range
+    # =========================================================================
+
+    async def get_boe_summary_range(self, arguments: Dict[str, Any]) -> List[TextContent]:
+        """Obtiene y agrega los sumarios del BOE para un rango de fechas.
+
+        Itera sobre cada día del rango (excluyendo domingos), recoge los documentos
+        y aplica filtros opcionales de sección y límite total.
+
+        Args:
+            arguments: Diccionario con from_date, to_date, section y max_items.
+
+        Returns:
+            TextContent con los documentos del rango agrupados por fecha.
+        """
+        try:
+            from_date_raw = arguments['from_date']
+            to_date_raw = arguments['to_date']
+            section = arguments.get('section')
+            max_items = arguments.get('max_items', 100)
+
+            from_date = format_date_for_api(from_date_raw)
+            to_date = format_date_for_api(to_date_raw)
+
+            if from_date > to_date:
+                raise ValueError("from_date debe ser anterior o igual a to_date.")
+
+            start_dt = datetime.strptime(from_date, '%Y%m%d')
+            end_dt = datetime.strptime(to_date, '%Y%m%d')
+            delta_days = (end_dt - start_dt).days
+
+            if delta_days > 31:
+                raise ValueError(
+                    f"El rango máximo es de 31 días. Se solicitaron {delta_days} días. "
+                    "Usa rangos más cortos o itera manualmente."
+                )
+
+            logger.info(f"Obteniendo sumario BOE rango {from_date}–{to_date}, sección={section}")
+
+            all_docs: List[Dict[str, Any]] = []
+            current_dt = start_dt
+            truncated = False
+
+            while current_dt <= end_dt:
+                if current_dt.weekday() == 6:  # domingo sin BOE
+                    current_dt += timedelta(days=1)
+                    continue
+
+                date_str = current_dt.strftime('%Y%m%d')
+                try:
+                    response = await self.client.get_boe_summary(date_str)
+                    if response.get('data'):
+                        day_docs = self._extract_matching_documents(
+                            response['data']['sumario'],
+                            date_str,
+                            search_terms=None,
+                            section_filter=section or 'all',
+                            department_filter=None
+                        )
+                        all_docs.extend(day_docs)
+                        if len(all_docs) >= max_items:
+                            all_docs = all_docs[:max_items]
+                            truncated = True
+                            break
+                except APIError:
+                    pass  # Día sin BOE (festivo, etc.)
+
+                current_dt += timedelta(days=1)
+
+            formatted = self._format_range_summary(all_docs, from_date_raw, to_date_raw, truncated, max_items)
+            return [TextContent(type="text", text=formatted)]
+
+        except ValueError as e:
+            return [TextContent(type="text", text=f"Parámetros inválidos: {str(e)}")]
+        except Exception as e:
+            logger.error(f"Error obteniendo sumario por rango: {e}")
+            return [TextContent(type="text", text=f"Error interno: {str(e)}")]
+
+    def _format_range_summary(
+        self,
+        docs: List[Dict[str, Any]],
+        from_date: str,
+        to_date: str,
+        truncated: bool,
+        max_items: int
+    ) -> str:
+        """Formatea el sumario de un rango de fechas."""
+        output = [
+            f"# 📰 Sumario BOE del {from_date} al {to_date}",
+            "",
+        ]
+
+        if not docs:
+            output.append("No se encontraron documentos en el rango especificado.")
+            return "\n".join(output)
+
+        output.append(f"**{len(docs)} documento(s) encontrado(s)**{'  *(resultado truncado)*' if truncated else ''}")
+        output.append("")
+
+        # Agrupar por fecha
+        by_date: Dict[str, List[Dict]] = {}
+        for doc in docs:
+            by_date.setdefault(doc['fecha'], []).append(doc)
+
+        for date_key in sorted(by_date.keys()):
+            try:
+                date_obj = datetime.strptime(date_key, '%Y%m%d')
+                formatted_date = date_obj.strftime('%d/%m/%Y')
+            except ValueError:
+                formatted_date = date_key
+
+            output.append(f"## {formatted_date} ({len(by_date[date_key])} docs)")
+            output.append("")
+            for doc in by_date[date_key]:
+                output.append(f"- **{doc['titulo']}**")
+                output.append(f"  - ID: `{doc['identificador']}` · {doc['departamento']}")
+                if doc.get('pdf_url'):
+                    output.append(f"  - PDF: {doc['pdf_url']}")
+                output.append("")
+
+        if truncated:
+            output.append(f"⚠️ Se alcanzó el límite de {max_items} documentos. Reduce el rango o aumenta max_items.")
+
+        return "\n".join(output)
+
+    # =========================================================================
+    # watch_boe_changes
+    # =========================================================================
+
+    async def watch_boe_changes(self, arguments: Dict[str, Any]) -> List[TextContent]:
+        """Busca publicaciones recientes del BOE que coincidan con palabras clave.
+
+        Args:
+            arguments: Diccionario con days_back, keywords, sections y max_items.
+
+        Returns:
+            TextContent con las publicaciones relevantes encontradas.
+        """
+        try:
+            days_back = arguments['days_back']
+            keywords_raw = arguments['keywords']
+            sections_raw = arguments.get('sections', '')
+            max_items = arguments.get('max_items', 50)
+
+            # Parsear keywords
+            keywords = [k.strip() for k in keywords_raw.replace(',', ' ').split() if k.strip()]
+            if not keywords:
+                raise ValueError("Debes proporcionar al menos una palabra clave.")
+
+            # Parsear secciones
+            section_set: Optional[set] = None
+            if sections_raw:
+                section_set = {s.strip() for s in sections_raw.split(',') if s.strip()}
+
+            end_dt = datetime.now()
+            start_dt = end_dt - timedelta(days=days_back)
+
+            logger.info(f"watch_boe_changes: {days_back} días, keywords={keywords}, sections={section_set}")
+
+            found_docs: List[Dict[str, Any]] = []
+            current_dt = start_dt
+
+            while current_dt <= end_dt and len(found_docs) < max_items:
+                if current_dt.weekday() == 6:
+                    current_dt += timedelta(days=1)
+                    continue
+
+                date_str = current_dt.strftime('%Y%m%d')
+                try:
+                    response = await self.client.get_boe_summary(date_str)
+                    if response.get('data'):
+                        for kw in keywords:
+                            day_docs = self._extract_matching_documents(
+                                response['data']['sumario'],
+                                date_str,
+                                search_terms=kw,
+                                section_filter='all',
+                                department_filter=None
+                            )
+                            # Filtrar secciones si se indicaron
+                            if section_set:
+                                day_docs = [
+                                    d for d in day_docs
+                                    if any(sec in d.get('seccion', '') for sec in section_set)
+                                ]
+                            for d in day_docs:
+                                # Evitar duplicados por identificador
+                                if not any(
+                                    existing['identificador'] == d['identificador']
+                                    for existing in found_docs
+                                ):
+                                    d['matched_keyword'] = kw
+                                    found_docs.append(d)
+                                    if len(found_docs) >= max_items:
+                                        break
+                            if len(found_docs) >= max_items:
+                                break
+                except APIError:
+                    pass
+
+                current_dt += timedelta(days=1)
+
+            formatted = self._format_watch_results(
+                found_docs, days_back, keywords,
+                max_items, len(found_docs) >= max_items
+            )
+            return [TextContent(type="text", text=formatted)]
+
+        except ValueError as e:
+            return [TextContent(type="text", text=f"Parámetros inválidos: {str(e)}")]
+        except Exception as e:
+            logger.error(f"Error en watch_boe_changes: {e}")
+            return [TextContent(type="text", text=f"Error interno: {str(e)}")]
+
+    def _format_watch_results(
+        self,
+        docs: List[Dict[str, Any]],
+        days_back: int,
+        keywords: List[str],
+        max_items: int,
+        truncated: bool
+    ) -> str:
+        """Formatea los resultados del radar normativo."""
+        kw_str = ', '.join(f'«{k}»' for k in keywords)
+        output = [
+            f"# 📡 Radar normativo — últimos {days_back} días",
+            f"**Palabras clave:** {kw_str}",
+            "",
+        ]
+
+        if not docs:
+            output.append(
+                f"No se encontraron publicaciones del BOE relacionadas con {kw_str} "
+                f"en los últimos {days_back} días."
+            )
+            return "\n".join(output)
+
+        output.append(
+            f"**{len(docs)} resultado(s)**{'  *(truncado a ' + str(max_items) + ')*' if truncated else ''}"
+        )
+        output.append("")
+
+        # Agrupar por fecha (más reciente primero)
+        by_date: Dict[str, List[Dict]] = {}
+        for doc in docs:
+            by_date.setdefault(doc['fecha'], []).append(doc)
+
+        for date_key in sorted(by_date.keys(), reverse=True):
+            try:
+                date_obj = datetime.strptime(date_key, '%Y%m%d')
+                formatted_date = date_obj.strftime('%d/%m/%Y')
+            except ValueError:
+                formatted_date = date_key
+
+            output.append(f"## {formatted_date}")
+            for doc in by_date[date_key]:
+                kw_match = doc.get('matched_keyword', '')
+                output.append(f"- **{doc['titulo']}**")
+                output.append(f"  - ID: `{doc['identificador']}` · {doc['departamento']}")
+                if kw_match:
+                    output.append(f"  - *Coincidencia: «{kw_match}»*")
+                if doc.get('pdf_url'):
+                    output.append(f"  - PDF: {doc['pdf_url']}")
+                output.append("")
+
+        return "\n".join(output)
+
+    # =========================================================================
+    # group_summary_by_department
+    # =========================================================================
+
+    async def group_summary_by_department(self, arguments: Dict[str, Any]) -> List[TextContent]:
+        """Obtiene el sumario de un rango de fechas y agrupa por departamento emisor.
+
+        Args:
+            arguments: Diccionario con from_date, to_date, sections y max_items_per_dept.
+
+        Returns:
+            TextContent con los departamentos ordenados por número de publicaciones.
+        """
+        try:
+            from_date_raw = arguments['from_date']
+            to_date_raw = arguments['to_date']
+            sections_raw = arguments.get('sections', '')
+            max_items_per_dept = arguments.get('max_items_per_dept', 10)
+
+            from_date = format_date_for_api(from_date_raw)
+            to_date = format_date_for_api(to_date_raw)
+
+            if from_date > to_date:
+                raise ValueError("from_date debe ser anterior o igual a to_date.")
+
+            start_dt = datetime.strptime(from_date, '%Y%m%d')
+            end_dt = datetime.strptime(to_date, '%Y%m%d')
+            delta_days = (end_dt - start_dt).days
+
+            if delta_days > 31:
+                raise ValueError(f"El rango máximo es de 31 días (se solicitaron {delta_days}).")
+
+            section_set: Optional[set] = None
+            if sections_raw:
+                section_set = {s.strip() for s in sections_raw.split(',') if s.strip()}
+
+            logger.info(f"group_summary_by_department: {from_date}–{to_date}, sections={section_set}")
+
+            # Recoger todos los documentos del rango
+            all_docs: List[Dict[str, Any]] = []
+            current_dt = start_dt
+
+            while current_dt <= end_dt:
+                if current_dt.weekday() == 6:
+                    current_dt += timedelta(days=1)
+                    continue
+
+                date_str = current_dt.strftime('%Y%m%d')
+                try:
+                    response = await self.client.get_boe_summary(date_str)
+                    if response.get('data'):
+                        day_docs = self._extract_matching_documents(
+                            response['data']['sumario'],
+                            date_str,
+                            search_terms=None,
+                            section_filter='all',
+                            department_filter=None
+                        )
+                        if section_set:
+                            day_docs = [
+                                d for d in day_docs
+                                if any(sec in d.get('seccion', '') for sec in section_set)
+                            ]
+                        all_docs.extend(day_docs)
+                except APIError:
+                    pass
+
+                current_dt += timedelta(days=1)
+
+            formatted = self._format_grouped_by_department(
+                all_docs, from_date_raw, to_date_raw, max_items_per_dept
+            )
+            return [TextContent(type="text", text=formatted)]
+
+        except ValueError as e:
+            return [TextContent(type="text", text=f"Parámetros inválidos: {str(e)}")]
+        except Exception as e:
+            logger.error(f"Error en group_summary_by_department: {e}")
+            return [TextContent(type="text", text=f"Error interno: {str(e)}")]
+
+    def _format_grouped_by_department(
+        self,
+        docs: List[Dict[str, Any]],
+        from_date: str,
+        to_date: str,
+        max_items_per_dept: int
+    ) -> str:
+        """Formatea los documentos agrupados por departamento."""
+        output = [
+            f"# 🏛️ Publicaciones BOE por departamento ({from_date} – {to_date})",
+            "",
+        ]
+
+        if not docs:
+            output.append("No se encontraron publicaciones en el rango especificado.")
+            return "\n".join(output)
+
+        # Agrupar por departamento
+        by_dept: Dict[str, List[Dict]] = {}
+        for doc in docs:
+            dept = doc.get('departamento', 'Sin departamento')
+            by_dept.setdefault(dept, []).append(doc)
+
+        # Ordenar departamentos por número de documentos (descendente)
+        sorted_depts = sorted(by_dept.items(), key=lambda x: len(x[1]), reverse=True)
+
+        output.append(
+            f"**{len(docs)} documentos · {len(sorted_depts)} departamentos**"
+        )
+        output.append("")
+
+        for dept_name, dept_docs in sorted_depts:
+            output.append(f"## {dept_name} ({len(dept_docs)} docs)")
+            output.append("")
+
+            for doc in dept_docs[:max_items_per_dept]:
+                output.append(f"- **{doc['titulo']}**")
+                output.append(f"  - ID: `{doc['identificador']}` · {doc['fecha']}")
+                if doc.get('pdf_url'):
+                    output.append(f"  - PDF: {doc['pdf_url']}")
+                output.append("")
+
+            if len(dept_docs) > max_items_per_dept:
+                output.append(
+                    f"  *(y {len(dept_docs) - max_items_per_dept} más — "
+                    "aumenta max_items_per_dept para ver todos)*"
+                )
+                output.append("")
+
+        return "\n".join(output)

--- a/src/mcp_boe/utils/http_client.py
+++ b/src/mcp_boe/utils/http_client.py
@@ -179,7 +179,6 @@ class BOEHTTPClient:
                     codigo=status_code,
                     mensaje=f"Error HTTP {status_code}",
                     detalles=str(e),
-                    timestamp=datetime.now()
                 )
         
         # Si llegamos aquí, fallaron todos los reintentos
@@ -187,7 +186,6 @@ class BOEHTTPClient:
             codigo=500,
             mensaje="Error de conexión después de varios reintentos",
             detalles=str(last_exception),
-            timestamp=datetime.now()
         )
 
     async def get(
@@ -253,7 +251,6 @@ class BOEHTTPClient:
                     codigo=500,
                     mensaje="Error parseando respuesta JSON de la API",
                     detalles=str(e),
-                    timestamp=datetime.now()
                 )
 
         elif accept_format == "application/xml":
@@ -266,14 +263,12 @@ class BOEHTTPClient:
                     codigo=500,
                     mensaje="Error parseando respuesta XML de la API",
                     detalles=str(e),
-                    timestamp=datetime.now()
                 )
 
         else:
             raise APIError(
                 codigo=400,
                 mensaje=f"Formato no soportado: {accept_format}",
-                timestamp=datetime.now()
             )
 
     def _xml_to_dict(self, element) -> Dict[str, Any]:
@@ -380,11 +375,78 @@ class BOEHTTPClient:
             Datos de la norma
         """
         endpoint = f"{self.ENDPOINTS['legislation']}/id/{law_id}"
-        
+
         if section:
             endpoint += f"/{section}"
-            
-        return await self.get(endpoint=endpoint)
+
+        # /texto solo funciona con XML; el resto responde JSON
+        if section == 'texto':
+            return await self._get_law_texto(endpoint)
+
+        response = await self.get(endpoint=endpoint)
+
+        # La API devuelve data como lista con un elemento; normalizamos a dict
+        # para que todos los tools puedan hacer response['data'].get(...) sin cambios.
+        if isinstance(response.get('data'), list) and response['data']:
+            response = {**response, 'data': response['data'][0]}
+
+        return response
+
+    async def _get_law_texto(self, endpoint: str) -> Dict[str, Any]:
+        """Obtiene y normaliza el texto de una norma desde XML.
+
+        El endpoint /texto solo acepta application/xml. Esta función descarga
+        el XML, lo parsea con lxml y lo normaliza al mismo formato dict que
+        usan los tools (data.texto → lista de bloques con id, tipo, titulo,
+        versiones[]{id_norma, fecha_vigencia, contenido_html}).
+        """
+        from lxml import etree
+
+        url = f"{self.BASE_URL}{endpoint}"
+        response = await self._make_request(
+            method="GET",
+            url=url,
+            headers={"Accept": "application/xml"},
+        )
+
+        try:
+            root = etree.fromstring(response.text.encode("utf-8"))
+        except etree.XMLSyntaxError as e:
+            raise APIError(codigo=500, mensaje=f"Error parseando XML de /texto: {e}")
+
+        bloques = []
+        for bloque_el in root.findall(".//texto/bloque"):
+            bloque_id = bloque_el.get("id", "")
+            bloque_tipo = bloque_el.get("tipo", "")
+
+            titulo_el = bloque_el.find("titulo")
+            titulo = titulo_el.text.strip() if titulo_el is not None and titulo_el.text else ""
+
+            versiones = []
+            for ver_el in bloque_el.findall("version"):
+                # Reconstruir contenido HTML concatenando todos los hijos
+                partes_html = []
+                for child in ver_el:
+                    try:
+                        partes_html.append(etree.tostring(child, encoding="unicode", with_tail=True))
+                    except Exception:
+                        pass
+                contenido_html = "".join(partes_html)
+                versiones.append({
+                    "id_norma": ver_el.get("id_norma", ""),
+                    "fecha_publicacion": ver_el.get("fecha_publicacion", ""),
+                    "fecha_vigencia": ver_el.get("fecha_vigencia", ""),
+                    "contenido_html": contenido_html,
+                })
+
+            bloques.append({
+                "id": bloque_id,
+                "tipo": bloque_tipo,
+                "titulo": titulo,
+                "versiones": versiones,
+            })
+
+        return {"data": {"texto": bloques}}
 
     async def get_boe_summary(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,252 @@
+"""
+Fixtures compartidos para los tests del servidor MCP-BOE.
+
+Usa unittest.mock para simular las llamadas HTTP al BOE, de modo que
+los tests sean reproducibles y no dependan de la conectividad real.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Respuestas JSON de ejemplo que simulan la API del BOE
+# ---------------------------------------------------------------------------
+
+SAMPLE_LAW_METADATA = {
+    "data": {
+        "fecha_actualizacion": "2023-10-09T12:23:33Z",
+        "identificador": "BOE-A-2015-10566",
+        "titulo": "Ley 40/2015, de 1 de octubre, de Régimen Jurídico del Sector Público.",
+        "fecha_publicacion": "20151002",
+        "fecha_vigencia": "20151103",
+        "fecha_derogacion": None,
+        "estatus_derogacion": "N",
+        "estatus_anulacion": "N",
+        "vigencia_agotada": "N",
+        "numero_oficial": "40/2015",
+        "diario": "BOE",
+        "diario_numero": "236",
+        "fecha_disposicion": "20151001",
+        "departamento": {"codigo": "7723", "texto": "Jefatura del Estado"},
+        "rango": {"codigo": "1300", "texto": "Ley"},
+        "ambito": {"codigo": "1", "texto": "Estatal"},
+        "estado_consolidacion": {"codigo": "1", "texto": "Finalizado"},
+        "url_eli": "https://www.boe.es/eli/es/l/2015/10/01/40",
+        "url_html_consolidada": "https://www.boe.es/buscar/act.php?id=BOE-A-2015-10566",
+    }
+}
+
+SAMPLE_LAW_ANALYSIS = {
+    "data": {
+        "materias": [
+            {"codigo": "2310", "texto": "Sector público"},
+            {"codigo": "7200", "texto": "Procedimiento administrativo"},
+        ],
+        "notas": [],
+        "referencias": {
+            "anteriores": [
+                {
+                    "id_norma": "BOE-A-1992-26318",
+                    "relacion": {"codigo": "1", "texto": "DEROGA"},
+                    "texto": "Ley 30/1992, de 26 de noviembre, de Régimen Jurídico..."
+                }
+            ],
+            "posteriores": [
+                {
+                    "id_norma": "BOE-A-2020-3824",
+                    "relacion": {"codigo": "2", "texto": "MODIFICA"},
+                    "texto": "Real Decreto-ley 11/2020, de 31 de marzo..."
+                }
+            ],
+        }
+    }
+}
+
+SAMPLE_LAW_TEXTO = {
+    "data": {
+        "texto": [
+            {
+                "id": "pr",
+                "tipo": "preambulo",
+                "titulo": "Preámbulo",
+                "versiones": [
+                    {
+                        "fecha_publicacion": "20151002",
+                        "fecha_vigencia": "20151103",
+                        "id_norma": "BOE-A-2015-10566",
+                        "contenido_html": "<p>Esta Ley tiene por objeto regular el régimen jurídico.</p>"
+                    }
+                ]
+            },
+            {
+                "id": "a1",
+                "tipo": "precepto",
+                "titulo": "Artículo 1. Objeto.",
+                "versiones": [
+                    {
+                        "fecha_publicacion": "20200101",
+                        "fecha_vigencia": "20200201",
+                        "id_norma": "BOE-A-2020-3824",
+                        "contenido_html": "<p>Esta Ley tiene por objeto establecer y regular los principios.</p>"
+                    },
+                    {
+                        "fecha_publicacion": "20151002",
+                        "fecha_vigencia": "20151103",
+                        "id_norma": "BOE-A-2015-10566",
+                        "contenido_html": "<p>Esta Ley tiene por objeto regular el régimen jurídico del sector público.</p>"
+                    }
+                ]
+            },
+            {
+                "id": "a2",
+                "tipo": "precepto",
+                "titulo": "Artículo 2. Ámbito subjetivo.",
+                "versiones": [
+                    {
+                        "fecha_publicacion": "20151002",
+                        "fecha_vigencia": "20151103",
+                        "id_norma": "BOE-A-2015-10566",
+                        "contenido_html": "<p>Las disposiciones de esta Ley se aplican al sector público.</p>"
+                    }
+                ]
+            },
+        ]
+    }
+}
+
+SAMPLE_LAW_INDICE = {
+    "data": {
+        "bloque": [
+            {"id": "pr", "titulo": "Preámbulo", "tipo": "preambulo", "fecha_actualizacion": "20151002"},
+            {"id": "a1", "titulo": "Artículo 1. Objeto.", "tipo": "precepto", "fecha_actualizacion": "20200201"},
+            {"id": "a2", "titulo": "Artículo 2. Ámbito subjetivo.", "tipo": "precepto", "fecha_actualizacion": "20151002"},
+            {"id": "dd", "titulo": "Disposición derogatoria única.", "tipo": "parte_dispositiva", "fecha_actualizacion": "20151002"},
+        ]
+    }
+}
+
+SAMPLE_BOE_SUMMARY = {
+    "data": {
+        "sumario": {
+            "diario": [
+                {
+                    "numero": "130",
+                    "sumario_diario": {
+                        "identificador": "BOE-S-2024-130",
+                        "url_pdf": "https://www.boe.es/boe/dias/2024/05/29/sumario.pdf",
+                        "size_bytes": 512000,
+                        "size_kbytes": 500,
+                    },
+                    "seccion": [
+                        {
+                            "codigo": "1",
+                            "nombre": "I. Disposiciones generales",
+                            "departamento": [
+                                {
+                                    "codigo": "7723",
+                                    "nombre": "Jefatura del Estado",
+                                    "item": [
+                                        {
+                                            "identificador": "BOE-A-2024-1234",
+                                            "titulo": "Real Decreto 123/2024 sobre procedimiento administrativo",
+                                            "url_pdf": "https://www.boe.es/boe/dias/2024/05/29/pdfs/BOE-A-2024-1234.pdf",
+                                            "url_html": "https://www.boe.es/diario_boe/txt.php?id=BOE-A-2024-1234",
+                                            "url_xml": "",
+                                            "size_bytes": 51200,
+                                            "size_kbytes": 50,
+                                            "pagina_inicial": 1,
+                                            "pagina_final": 10,
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}
+
+SAMPLE_DEPARTMENTS_TABLE = {
+    "data": {
+        "nombre": "departamentos",
+        "descripcion": "Tabla de departamentos",
+        "fecha_actualizacion": "2024-01-01T00:00:00Z",
+        "entradas": [
+            {"codigo": "7723", "descripcion": "Jefatura del Estado", "activo": True},
+            {"codigo": "1430", "descripcion": "Ministerio de Justicia", "activo": True},
+            {"codigo": "1470", "descripcion": "Ministerio del Interior", "activo": True},
+            {"codigo": "1431", "descripcion": "Secretaría de Estado de Justicia", "activo": True},
+        ],
+        "total_entradas": 4,
+    }
+}
+
+SAMPLE_RANGES_TABLE = {
+    "data": {
+        "nombre": "rangos",
+        "descripcion": "Tabla de rangos normativos",
+        "fecha_actualizacion": "2024-01-01T00:00:00Z",
+        "entradas": [
+            {"codigo": "1300", "descripcion": "Ley", "activo": True},
+            {"codigo": "1250", "descripcion": "Ley Orgánica", "activo": True},
+            {"codigo": "1200", "descripcion": "Real Decreto", "activo": True},
+            {"codigo": "1100", "descripcion": "Real Decreto-ley", "activo": True},
+        ],
+        "total_entradas": 4,
+    }
+}
+
+SAMPLE_MATTERS_TABLE = {
+    "data": {
+        "nombre": "materias",
+        "descripcion": "Tabla de materias",
+        "fecha_actualizacion": "2024-01-01T00:00:00Z",
+        "entradas": [
+            {"codigo": "2310", "descripcion": "Sector público", "activo": True},
+            {"codigo": "7200", "descripcion": "Procedimiento administrativo", "activo": True},
+            {"codigo": "5000", "descripcion": "Medio ambiente", "activo": True},
+        ],
+        "total_entradas": 3,
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixture: mock del cliente HTTP
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_http_client():
+    """Cliente HTTP simulado que devuelve datos de ejemplo predefinidos."""
+    client = MagicMock()
+
+    async def _get_law_by_id(law_id, section):
+        if section == 'metadatos':
+            return SAMPLE_LAW_METADATA
+        elif section == 'analisis':
+            return SAMPLE_LAW_ANALYSIS
+        elif section == 'texto':
+            return SAMPLE_LAW_TEXTO
+        elif section == 'texto/indice':
+            return SAMPLE_LAW_INDICE
+        return {"data": None}
+
+    async def _get_boe_summary(date):
+        return SAMPLE_BOE_SUMMARY
+
+    async def _get_auxiliary_table(table_name):
+        tables = {
+            'departamentos': SAMPLE_DEPARTMENTS_TABLE,
+            'rangos': SAMPLE_RANGES_TABLE,
+            'materias': SAMPLE_MATTERS_TABLE,
+        }
+        return tables.get(table_name, {"data": None})
+
+    client.get_law_by_id = AsyncMock(side_effect=_get_law_by_id)
+    client.get_boe_summary = AsyncMock(side_effect=_get_boe_summary)
+    client.get_auxiliary_table = AsyncMock(side_effect=_get_auxiliary_table)
+
+    return client

--- a/tests/test_analysis_tools.py
+++ b/tests/test_analysis_tools.py
@@ -1,0 +1,210 @@
+"""
+Tests para las herramientas del grupo D (análisis / calidad de vida).
+
+Cubre: summarize_law_sections, paginate_law_text, explain_law_structure,
+       normalize_boe_reference.
+"""
+
+import base64
+import pytest
+from mcp.types import TextContent
+
+from mcp_boe.tools.analysis import AnalysisTools
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tools(mock_http_client):
+    return AnalysisTools(mock_http_client)
+
+
+# ---------------------------------------------------------------------------
+# summarize_law_sections
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_summarize_law_sections_returns_text(tools):
+    result = await tools.summarize_law_sections({"law_id": "BOE-A-2015-10566"})
+    assert len(result) == 1
+    assert isinstance(result[0], TextContent)
+    text = result[0].text
+    assert "BOE-A-2015-10566" in text
+    assert "Preámbulo" in text or "preambulo" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_summarize_law_sections_includes_articles(tools):
+    result = await tools.summarize_law_sections({"law_id": "BOE-A-2015-10566"})
+    text = result[0].text
+    assert "Artículo 1" in text
+    assert "Artículo 2" in text
+
+
+@pytest.mark.asyncio
+async def test_summarize_law_sections_invalid_id(tools):
+    result = await tools.summarize_law_sections({"law_id": "INVALID-ID"})
+    assert "inválido" in result[0].text.lower() or "Error" in result[0].text
+
+
+# ---------------------------------------------------------------------------
+# paginate_law_text
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_paginate_law_text_first_page(tools):
+    result = await tools.paginate_law_text({"law_id": "BOE-A-2015-10566"})
+    text = result[0].text
+    # La primera página debe contener bloques
+    assert "BOE-A-2015-10566" in text
+    assert "Bloques incluidos" in text
+
+
+@pytest.mark.asyncio
+async def test_paginate_law_text_small_max_chars(tools):
+    """Con max_chars muy pequeño debe paginar en múltiples páginas."""
+    result = await tools.paginate_law_text({
+        "law_id": "BOE-A-2015-10566",
+        "max_chars": 50,  # muy pequeño para forzar paginación
+    })
+    text = result[0].text
+    # Puede que haya next_cursor o que sea la última página
+    assert "BOE-A-2015-10566" in text
+
+
+@pytest.mark.asyncio
+async def test_paginate_law_text_cursor_navigation(tools):
+    """El cursor de la primera página debe permitir acceder a la siguiente."""
+    # Primera página con max_chars pequeño para garantizar paginación
+    result1 = await tools.paginate_law_text({
+        "law_id": "BOE-A-2015-10566",
+        "max_chars": 100,
+    })
+    text1 = result1[0].text
+
+    # Si hay next_cursor, extraerlo y usarlo
+    if "Siguiente cursor:" in text1:
+        # Extraer cursor del texto
+        for line in text1.split('\n'):
+            if "Siguiente cursor:" in line:
+                cursor = line.split('`')[1] if '`' in line else None
+                if cursor:
+                    result2 = await tools.paginate_law_text({
+                        "law_id": "BOE-A-2015-10566",
+                        "cursor": cursor,
+                        "max_chars": 100,
+                    })
+                    assert isinstance(result2[0], TextContent)
+                break
+
+
+@pytest.mark.asyncio
+async def test_paginate_law_text_invalid_cursor(tools):
+    result = await tools.paginate_law_text({
+        "law_id": "BOE-A-2015-10566",
+        "cursor": "cursor_completamente_invalido!!!",
+    })
+    # Debe manejar el error con gracia
+    assert "Error" in result[0].text or "inválido" in result[0].text.lower()
+
+
+# ---------------------------------------------------------------------------
+# explain_law_structure
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_explain_law_structure_returns_text(tools):
+    result = await tools.explain_law_structure({"law_id": "BOE-A-2015-10566"})
+    text = result[0].text
+    assert "BOE-A-2015-10566" in text
+    assert "Artículo" in text or "artículo" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_explain_law_structure_shows_element_counts(tools):
+    result = await tools.explain_law_structure({"law_id": "BOE-A-2015-10566"})
+    text = result[0].text
+    # Debe mencionar el número de elementos en cada sección
+    assert "elemento" in text.lower() or "(" in text
+
+
+@pytest.mark.asyncio
+async def test_explain_law_structure_invalid_id(tools):
+    result = await tools.explain_law_structure({"law_id": "NOPE"})
+    assert "inválido" in result[0].text.lower() or "Error" in result[0].text
+
+
+# ---------------------------------------------------------------------------
+# normalize_boe_reference
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_normalize_boe_id(tools):
+    result = await tools.normalize_boe_reference({"reference_text": "BOE-A-2015-10566"})
+    text = result[0].text
+    assert "law" in text.lower() or "BOE-A-2015-10566" in text
+    assert "Norma" in text or "law" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_normalize_ley(tools):
+    result = await tools.normalize_boe_reference({"reference_text": "Ley 40/2015"})
+    text = result[0].text
+    assert "40/2015" in text
+    assert "law" in text.lower() or "Norma" in text
+
+
+@pytest.mark.asyncio
+async def test_normalize_ley_organica(tools):
+    result = await tools.normalize_boe_reference({"reference_text": "Ley Orgánica 3/2018"})
+    text = result[0].text
+    assert "3/2018" in text
+    assert "Orgánica" in text or "orgánica" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_normalize_real_decreto(tools):
+    result = await tools.normalize_boe_reference({"reference_text": "Real Decreto 123/2020"})
+    text = result[0].text
+    assert "123/2020" in text
+
+
+@pytest.mark.asyncio
+async def test_normalize_orden_ministerial(tools):
+    result = await tools.normalize_boe_reference({"reference_text": "Orden TED/1234/2023"})
+    text = result[0].text
+    assert "TED" in text
+    assert "1234/2023" in text
+    assert "order" in text.lower() or "Orden" in text
+
+
+@pytest.mark.asyncio
+async def test_normalize_boe_por_fecha(tools):
+    result = await tools.normalize_boe_reference({
+        "reference_text": "BOE del 3 de mayo de 2024, sección I"
+    })
+    text = result[0].text
+    assert "boe_issue" in text.lower() or "BOE" in text
+    assert "20240503" in text or "mayo" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_normalize_boe_fecha_numerica(tools):
+    result = await tools.normalize_boe_reference({"reference_text": "BOE de 3/5/2024"})
+    text = result[0].text
+    assert "20240503" in text or "3/5/2024" in text or "3/05/2024" in text
+
+
+@pytest.mark.asyncio
+async def test_normalize_unknown(tools):
+    result = await tools.normalize_boe_reference({"reference_text": "texto completamente irreconocible xyz"})
+    text = result[0].text
+    assert "unknown" in text.lower() or "No reconocido" in text or "no reconoc" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_normalize_empty_text(tools):
+    result = await tools.normalize_boe_reference({"reference_text": ""})
+    assert "Error" in result[0].text or "vacío" in result[0].text.lower()

--- a/tests/test_auxiliary_advanced.py
+++ b/tests/test_auxiliary_advanced.py
@@ -1,0 +1,239 @@
+"""
+Tests para las herramientas avanzadas del grupo C (tablas auxiliares).
+
+Cubre: search_departments_advanced, list_topics_for_law,
+       suggest_auxiliary_filters.
+"""
+
+import pytest
+from mcp.types import TextContent
+
+from mcp_boe.tools.auxiliary import AuxiliaryTools
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tools(mock_http_client):
+    return AuxiliaryTools(mock_http_client)
+
+
+# ---------------------------------------------------------------------------
+# search_departments_advanced
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_search_departments_advanced_returns_list(tools):
+    result = await tools.search_departments_advanced({})
+    assert len(result) == 1
+    assert isinstance(result[0], TextContent)
+    text = result[0].text
+    assert "departamento" in text.lower() or "Departamento" in text
+
+
+@pytest.mark.asyncio
+async def test_search_departments_advanced_with_search_term(tools):
+    result = await tools.search_departments_advanced({
+        "search_term": "Jefatura",
+    })
+    text = result[0].text
+    assert "Jefatura" in text
+
+
+@pytest.mark.asyncio
+async def test_search_departments_advanced_no_results(tools):
+    result = await tools.search_departments_advanced({
+        "search_term": "xyzzy_inexistente_42",
+    })
+    text = result[0].text
+    assert "No se encontraron" in text or "no se encontraron" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_search_departments_advanced_parent_code_filter(tools):
+    """El filtro parent_code debe devolver solo departamentos con ese prefijo de código."""
+    result = await tools.search_departments_advanced({
+        "parent_code": "1430",
+    })
+    text = result[0].text
+    # Solo el código 1430 y 1431 empiezan por "143"
+    # Con parent_code="1430" solo debe aparecer código 1430 exacto (startswith)
+    assert isinstance(result[0], TextContent)
+
+
+@pytest.mark.asyncio
+async def test_search_departments_advanced_limit(tools):
+    result = await tools.search_departments_advanced({
+        "limit": 2,
+    })
+    text = result[0].text
+    assert isinstance(result[0], TextContent)
+    # Con la muestra de 4 departamentos y limit=2, debe mostrar como máximo 2
+    dept_items = [l for l in text.split('\n') if l.strip().startswith("- **")]
+    assert len(dept_items) <= 2
+
+
+@pytest.mark.asyncio
+async def test_search_departments_advanced_includes_code(tools):
+    result = await tools.search_departments_advanced({
+        "search_term": "Justicia",
+    })
+    text = result[0].text
+    # Debe mostrar el código del departamento
+    assert "1430" in text or "Justicia" in text
+
+
+@pytest.mark.asyncio
+async def test_search_departments_advanced_active_only_default(tools):
+    """Por defecto debe devolver solo activos."""
+    result = await tools.search_departments_advanced({})
+    assert isinstance(result[0], TextContent)
+    # En la muestra todos son activos, así que deben aparecer todos
+    text = result[0].text
+    assert "Jefatura" in text
+
+
+# ---------------------------------------------------------------------------
+# list_topics_for_law
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_list_topics_for_law_returns_text(tools):
+    result = await tools.list_topics_for_law({"law_id": "BOE-A-2015-10566"})
+    assert len(result) == 1
+    assert isinstance(result[0], TextContent)
+    text = result[0].text
+    assert "BOE-A-2015-10566" in text
+
+
+@pytest.mark.asyncio
+async def test_list_topics_for_law_shows_materia(tools):
+    """Debe listar 'Sector público' y 'Procedimiento administrativo'."""
+    result = await tools.list_topics_for_law({"law_id": "BOE-A-2015-10566"})
+    text = result[0].text
+    assert "Sector público" in text or "sector" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_list_topics_for_law_shows_codes(tools):
+    result = await tools.list_topics_for_law({"law_id": "BOE-A-2015-10566"})
+    text = result[0].text
+    # Los códigos de materias en la muestra son 2310 y 7200
+    assert "2310" in text or "7200" in text
+
+
+@pytest.mark.asyncio
+async def test_list_topics_for_law_invalid_id(tools):
+    result = await tools.list_topics_for_law({"law_id": "BAD"})
+    assert "inválido" in result[0].text.lower() or "Error" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_list_topics_for_law_multiple_topics(tools):
+    """Con dos materias en la muestra debe listar ambas."""
+    result = await tools.list_topics_for_law({"law_id": "BOE-A-2015-10566"})
+    text = result[0].text
+    # Ambas materias deben estar presentes
+    assert "Sector público" in text or "2310" in text
+    assert "Procedimiento" in text or "7200" in text
+
+
+# ---------------------------------------------------------------------------
+# suggest_auxiliary_filters
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_suggest_auxiliary_filters_returns_text(tools):
+    result = await tools.suggest_auxiliary_filters({
+        "query": "público",
+    })
+    assert len(result) == 1
+    assert isinstance(result[0], TextContent)
+    text = result[0].text
+    assert "público" in text.lower() or "filtro" in text.lower() or "sugerencia" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_suggest_auxiliary_filters_finds_department(tools):
+    result = await tools.suggest_auxiliary_filters({
+        "query": "Jefatura",
+    })
+    text = result[0].text
+    assert "Jefatura" in text
+
+
+@pytest.mark.asyncio
+async def test_suggest_auxiliary_filters_finds_range(tools):
+    result = await tools.suggest_auxiliary_filters({
+        "query": "Ley",
+    })
+    text = result[0].text
+    # La tabla de rangos tiene "Ley" y "Ley Orgánica"
+    assert "Ley" in text
+
+
+@pytest.mark.asyncio
+async def test_suggest_auxiliary_filters_finds_topic(tools):
+    result = await tools.suggest_auxiliary_filters({
+        "query": "Medio",
+    })
+    text = result[0].text
+    # La tabla de materias tiene "Medio ambiente"
+    assert "Medio" in text or "ambiente" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_suggest_auxiliary_filters_no_match(tools):
+    result = await tools.suggest_auxiliary_filters({
+        "query": "xyzzy_inexistente_42",
+    })
+    text = result[0].text
+    assert "no se encontraron" in text.lower() or "0 sugerencia" in text.lower() or "No se encontraron" in text
+
+
+@pytest.mark.asyncio
+async def test_suggest_auxiliary_filters_empty_query(tools):
+    result = await tools.suggest_auxiliary_filters({
+        "query": "  ",
+    })
+    text = result[0].text
+    assert "Parámetros inválidos" in text or "vacío" in text.lower() or "Error" in text
+
+
+@pytest.mark.asyncio
+async def test_suggest_auxiliary_filters_max_suggestions(tools):
+    """Con max_suggestions=1 debe devolver como máximo 1 sugerencia."""
+    result = await tools.suggest_auxiliary_filters({
+        "query": "e",  # coincide con muchos
+        "max_suggestions": 1,
+    })
+    text = result[0].text
+    assert isinstance(result[0], TextContent)
+    suggestion_lines = [l for l in text.split('\n') if l.strip().startswith("- ")]
+    assert len(suggestion_lines) <= 1
+
+
+@pytest.mark.asyncio
+async def test_suggest_auxiliary_filters_shows_type(tools):
+    """Cada sugerencia debe indicar su tipo (department/range/topic)."""
+    result = await tools.suggest_auxiliary_filters({
+        "query": "Justicia",
+    })
+    text = result[0].text
+    if "Justicia" in text:  # Si hay coincidencias
+        assert "department" in text.lower() or "tipo" in text.lower() or "Departamento" in text
+
+
+@pytest.mark.asyncio
+async def test_suggest_auxiliary_filters_mixed_results(tools):
+    """'sector' aparece en materias; debe devolver sugerencias de tipo topic."""
+    result = await tools.suggest_auxiliary_filters({
+        "query": "sector",
+    })
+    text = result[0].text
+    assert isinstance(result[0], TextContent)
+    # "Sector público" aparece en materias (SAMPLE_MATTERS_TABLE)
+    if "Sector" in text:
+        assert "topic" in text.lower() or "materia" in text.lower() or "2310" in text

--- a/tests/test_legislation_advanced.py
+++ b/tests/test_legislation_advanced.py
@@ -1,0 +1,268 @@
+"""
+Tests para las herramientas avanzadas del grupo A (legislación).
+
+Cubre: compare_law_versions, search_law_articles, get_law_metadata,
+       list_related_laws.
+"""
+
+import pytest
+from mcp.types import TextContent
+
+from mcp_boe.tools.legislation import LegislationTools
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tools(mock_http_client):
+    return LegislationTools(mock_http_client)
+
+
+# ---------------------------------------------------------------------------
+# compare_law_versions
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_compare_law_versions_no_changes(tools):
+    """Cuando from_date y to_date caen en la misma versión debe indicar sin cambios."""
+    result = await tools.compare_law_versions({
+        "law_id": "BOE-A-2015-10566",
+        "from_date": "20151002",
+        "to_date": "20151103",
+    })
+    assert len(result) == 1
+    assert isinstance(result[0], TextContent)
+    text = result[0].text
+    assert "BOE-A-2015-10566" in text
+
+
+@pytest.mark.asyncio
+async def test_compare_law_versions_detects_modification(tools):
+    """Cuando hay versiones distintas entre fechas debe detectar modificados."""
+    result = await tools.compare_law_versions({
+        "law_id": "BOE-A-2015-10566",
+        "from_date": "20151002",
+        "to_date": "20210101",
+    })
+    text = result[0].text
+    # El artículo a1 tiene dos versiones en SAMPLE_LAW_TEXTO con fechas distintas
+    assert "modificado" in text.lower() or "Modificado" in text or "modificados" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_compare_law_versions_invalid_id(tools):
+    result = await tools.compare_law_versions({
+        "law_id": "INVALID",
+        "from_date": "20200101",
+        "to_date": "20210101",
+    })
+    assert "inválido" in result[0].text.lower() or "Error" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_compare_law_versions_from_date_after_to_date(tools):
+    result = await tools.compare_law_versions({
+        "law_id": "BOE-A-2015-10566",
+        "from_date": "20220101",
+        "to_date": "20200101",
+    })
+    assert "Error" in result[0].text or "anterior" in result[0].text.lower()
+
+
+@pytest.mark.asyncio
+async def test_compare_law_versions_iso_date_format(tools):
+    """Las fechas en formato ISO YYYY-MM-DD deben aceptarse."""
+    result = await tools.compare_law_versions({
+        "law_id": "BOE-A-2015-10566",
+        "from_date": "2015-10-02",
+        "to_date": "2021-01-01",
+    })
+    # No debe devolver error de formato
+    assert "Error" not in result[0].text or "formato" not in result[0].text.lower()
+
+
+@pytest.mark.asyncio
+async def test_compare_law_versions_granularity_articulo(tools):
+    result = await tools.compare_law_versions({
+        "law_id": "BOE-A-2015-10566",
+        "from_date": "20151002",
+        "to_date": "20210101",
+        "granularity": "articulo",
+    })
+    assert isinstance(result[0], TextContent)
+
+
+# ---------------------------------------------------------------------------
+# search_law_articles
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_search_law_articles_finds_match(tools):
+    """Buscar 'objeto' en la muestra debe encontrar el artículo 1."""
+    result = await tools.search_law_articles({
+        "law_id": "BOE-A-2015-10566",
+        "query": "objeto",
+    })
+    text = result[0].text
+    assert "a1" in text or "Artículo 1" in text
+
+
+@pytest.mark.asyncio
+async def test_search_law_articles_no_match(tools):
+    result = await tools.search_law_articles({
+        "law_id": "BOE-A-2015-10566",
+        "query": "xyzzy_inexistente_42",
+    })
+    text = result[0].text
+    assert "no se encontraron" in text.lower() or "0 artículo" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_search_law_articles_search_in_titulo(tools):
+    result = await tools.search_law_articles({
+        "law_id": "BOE-A-2015-10566",
+        "query": "Objeto",
+        "search_in": "titulo",
+    })
+    assert isinstance(result[0], TextContent)
+    # Artículo 1 tiene "Objeto" en el título
+    assert "a1" in result[0].text or "Artículo 1" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_search_law_articles_search_in_texto(tools):
+    result = await tools.search_law_articles({
+        "law_id": "BOE-A-2015-10566",
+        "query": "sector público",
+        "search_in": "texto",
+    })
+    assert isinstance(result[0], TextContent)
+
+
+@pytest.mark.asyncio
+async def test_search_law_articles_invalid_id(tools):
+    result = await tools.search_law_articles({
+        "law_id": "NO-VALID",
+        "query": "objeto",
+    })
+    assert "inválido" in result[0].text.lower() or "Error" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_search_law_articles_empty_query(tools):
+    result = await tools.search_law_articles({
+        "law_id": "BOE-A-2015-10566",
+        "query": "   ",
+    })
+    assert "Error" in result[0].text or "vacío" in result[0].text.lower()
+
+
+@pytest.mark.asyncio
+async def test_search_law_articles_limit(tools):
+    """Con limit=1 debe devolver como máximo 1 artículo."""
+    result = await tools.search_law_articles({
+        "law_id": "BOE-A-2015-10566",
+        "query": "esta ley",
+        "limit": 1,
+    })
+    text = result[0].text
+    assert isinstance(result[0], TextContent)
+    # No debe listar más de 1 resultado de artículo
+    article_headers = [line for line in text.split('\n') if line.startswith('###')]
+    assert len(article_headers) <= 1
+
+
+# ---------------------------------------------------------------------------
+# get_law_metadata
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_law_metadata_returns_title(tools):
+    result = await tools.get_law_metadata({"law_id": "BOE-A-2015-10566"})
+    assert len(result) == 1
+    text = result[0].text
+    assert "BOE-A-2015-10566" in text
+    assert "Ley" in text or "Régimen" in text
+
+
+@pytest.mark.asyncio
+async def test_get_law_metadata_shows_publication_date(tools):
+    result = await tools.get_law_metadata({"law_id": "BOE-A-2015-10566"})
+    text = result[0].text
+    # Fecha de publicación 20151002 → debe aparecer en algún formato
+    assert "2015" in text
+
+
+@pytest.mark.asyncio
+async def test_get_law_metadata_shows_department(tools):
+    result = await tools.get_law_metadata({"law_id": "BOE-A-2015-10566"})
+    text = result[0].text
+    assert "Jefatura" in text or "Estado" in text
+
+
+@pytest.mark.asyncio
+async def test_get_law_metadata_shows_legal_range(tools):
+    result = await tools.get_law_metadata({"law_id": "BOE-A-2015-10566"})
+    text = result[0].text
+    assert "Ley" in text
+
+
+@pytest.mark.asyncio
+async def test_get_law_metadata_invalid_id(tools):
+    result = await tools.get_law_metadata({"law_id": "BAD-ID"})
+    assert "inválido" in result[0].text.lower() or "Error" in result[0].text
+
+
+# ---------------------------------------------------------------------------
+# list_related_laws
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_list_related_laws_returns_text(tools):
+    result = await tools.list_related_laws({"law_id": "BOE-A-2015-10566"})
+    assert len(result) == 1
+    assert isinstance(result[0], TextContent)
+    text = result[0].text
+    assert "BOE-A-2015-10566" in text
+
+
+@pytest.mark.asyncio
+async def test_list_related_laws_shows_references(tools):
+    """Debe mostrar las referencias anteriores y posteriores de la muestra."""
+    result = await tools.list_related_laws({"law_id": "BOE-A-2015-10566"})
+    text = result[0].text
+    # SAMPLE_LAW_ANALYSIS tiene referencias anteriores y posteriores
+    assert "BOE-A-1992-26318" in text or "BOE-A-2020-3824" in text
+
+
+@pytest.mark.asyncio
+async def test_list_related_laws_only_derogating(tools):
+    result = await tools.list_related_laws({
+        "law_id": "BOE-A-2015-10566",
+        "include_derogating": True,
+        "include_development": False,
+        "include_references": False,
+    })
+    assert isinstance(result[0], TextContent)
+
+
+@pytest.mark.asyncio
+async def test_list_related_laws_none_included(tools):
+    """Con todos los flags en False no debe mostrar relaciones."""
+    result = await tools.list_related_laws({
+        "law_id": "BOE-A-2015-10566",
+        "include_derogating": False,
+        "include_development": False,
+        "include_references": False,
+    })
+    text = result[0].text
+    # Debe indicar que no hay relaciones visibles
+    assert "no se encontraron" in text.lower() or "0 relación" in text.lower() or "No se encontraron" in text
+
+
+@pytest.mark.asyncio
+async def test_list_related_laws_invalid_id(tools):
+    result = await tools.list_related_laws({"law_id": "NOT-A-LAW"})
+    assert "inválido" in result[0].text.lower() or "Error" in result[0].text

--- a/tests/test_summaries_advanced.py
+++ b/tests/test_summaries_advanced.py
@@ -1,0 +1,263 @@
+"""
+Tests para las herramientas avanzadas del grupo B (radar normativo).
+
+Cubre: get_boe_summary_range, watch_boe_changes, group_summary_by_department.
+"""
+
+import pytest
+from mcp.types import TextContent
+
+from mcp_boe.tools.summaries import SummaryTools
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tools(mock_http_client):
+    return SummaryTools(mock_http_client)
+
+
+# ---------------------------------------------------------------------------
+# get_boe_summary_range
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_boe_summary_range_returns_text(tools):
+    result = await tools.get_boe_summary_range({
+        "from_date": "20240529",
+        "to_date": "20240530",
+    })
+    assert len(result) == 1
+    assert isinstance(result[0], TextContent)
+    text = result[0].text
+    assert "Sumario BOE" in text or "sumario" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_get_boe_summary_range_shows_documents(tools):
+    """Debe listar documentos del SAMPLE_BOE_SUMMARY."""
+    result = await tools.get_boe_summary_range({
+        "from_date": "20240529",
+        "to_date": "20240529",
+    })
+    text = result[0].text
+    assert "BOE-A-2024-1234" in text or "Real Decreto" in text
+
+
+@pytest.mark.asyncio
+async def test_get_boe_summary_range_exceeds_31_days(tools):
+    """Rango superior a 31 días debe devolver error."""
+    result = await tools.get_boe_summary_range({
+        "from_date": "20240101",
+        "to_date": "20240301",
+    })
+    text = result[0].text
+    assert "31" in text or "rango" in text.lower() or "inválido" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_get_boe_summary_range_inverted_dates(tools):
+    """from_date posterior a to_date debe devolver error."""
+    result = await tools.get_boe_summary_range({
+        "from_date": "20240530",
+        "to_date": "20240529",
+    })
+    text = result[0].text
+    assert "anterior" in text.lower() or "inválido" in text.lower() or "Error" in text
+
+
+@pytest.mark.asyncio
+async def test_get_boe_summary_range_section_filter(tools):
+    """Filtrar por sección no debe causar error."""
+    result = await tools.get_boe_summary_range({
+        "from_date": "20240529",
+        "to_date": "20240529",
+        "section": "1",
+    })
+    assert isinstance(result[0], TextContent)
+
+
+@pytest.mark.asyncio
+async def test_get_boe_summary_range_max_items(tools):
+    """max_items=1 debe truncar a 1 documento."""
+    result = await tools.get_boe_summary_range({
+        "from_date": "20240529",
+        "to_date": "20240529",
+        "max_items": 1,
+    })
+    text = result[0].text
+    assert isinstance(result[0], TextContent)
+    # Con max_items=1 el número de filas "-" de item no debe ser más de 1
+    items = [l for l in text.split('\n') if l.strip().startswith("- **")]
+    assert len(items) <= 1
+
+
+@pytest.mark.asyncio
+async def test_get_boe_summary_range_iso_dates(tools):
+    """Fechas en formato ISO YYYY-MM-DD deben aceptarse."""
+    result = await tools.get_boe_summary_range({
+        "from_date": "2024-05-29",
+        "to_date": "2024-05-30",
+    })
+    assert "Error" not in result[0].text or "formato" not in result[0].text.lower()
+
+
+# ---------------------------------------------------------------------------
+# watch_boe_changes
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_watch_boe_changes_returns_text(tools):
+    result = await tools.watch_boe_changes({
+        "days_back": 3,
+        "keywords": "procedimiento",
+    })
+    assert len(result) == 1
+    assert isinstance(result[0], TextContent)
+    text = result[0].text
+    assert "Radar normativo" in text or "radar" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_watch_boe_changes_finds_matching_document(tools):
+    """El SAMPLE_BOE_SUMMARY tiene 'procedimiento administrativo' en el título."""
+    result = await tools.watch_boe_changes({
+        "days_back": 5,
+        "keywords": "procedimiento",
+    })
+    text = result[0].text
+    # Debe encontrar el documento de la muestra
+    assert "BOE-A-2024-1234" in text or "procedimiento" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_watch_boe_changes_no_match(tools):
+    result = await tools.watch_boe_changes({
+        "days_back": 3,
+        "keywords": "xyzzy_palabra_inexistente_42",
+    })
+    text = result[0].text
+    assert "no se encontraron" in text.lower() or "0 resultado" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_watch_boe_changes_empty_keywords(tools):
+    result = await tools.watch_boe_changes({
+        "days_back": 3,
+        "keywords": "   ",
+    })
+    text = result[0].text
+    assert "Parámetros inválidos" in text or "clave" in text.lower() or "Error" in text
+
+
+@pytest.mark.asyncio
+async def test_watch_boe_changes_multiple_keywords(tools):
+    """Varias palabras clave deben hacer búsquedas independientes."""
+    result = await tools.watch_boe_changes({
+        "days_back": 3,
+        "keywords": "procedimiento decreto",
+    })
+    assert isinstance(result[0], TextContent)
+
+
+@pytest.mark.asyncio
+async def test_watch_boe_changes_max_items(tools):
+    result = await tools.watch_boe_changes({
+        "days_back": 5,
+        "keywords": "procedimiento",
+        "max_items": 2,
+    })
+    assert isinstance(result[0], TextContent)
+
+
+@pytest.mark.asyncio
+async def test_watch_boe_changes_shows_matched_keyword(tools):
+    """El output debe indicar qué keyword produjo cada coincidencia."""
+    result = await tools.watch_boe_changes({
+        "days_back": 5,
+        "keywords": "procedimiento",
+    })
+    text = result[0].text
+    if "BOE-A-2024-1234" in text:  # Si encontró resultados
+        assert "procedimiento" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# group_summary_by_department
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_group_summary_by_department_returns_text(tools):
+    result = await tools.group_summary_by_department({
+        "from_date": "20240529",
+        "to_date": "20240529",
+    })
+    assert len(result) == 1
+    assert isinstance(result[0], TextContent)
+    text = result[0].text
+    assert "departamento" in text.lower() or "Departamento" in text
+
+
+@pytest.mark.asyncio
+async def test_group_summary_by_department_shows_dept_name(tools):
+    """Debe agrupar por 'Jefatura del Estado' que viene en SAMPLE_BOE_SUMMARY."""
+    result = await tools.group_summary_by_department({
+        "from_date": "20240529",
+        "to_date": "20240529",
+    })
+    text = result[0].text
+    assert "Jefatura" in text or "Estado" in text
+
+
+@pytest.mark.asyncio
+async def test_group_summary_by_department_exceeds_31_days(tools):
+    result = await tools.group_summary_by_department({
+        "from_date": "20240101",
+        "to_date": "20240301",
+    })
+    text = result[0].text
+    assert "31" in text or "inválido" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_group_summary_by_department_inverted_dates(tools):
+    result = await tools.group_summary_by_department({
+        "from_date": "20240530",
+        "to_date": "20240529",
+    })
+    text = result[0].text
+    assert "anterior" in text.lower() or "inválido" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_group_summary_by_department_max_items_per_dept(tools):
+    result = await tools.group_summary_by_department({
+        "from_date": "20240529",
+        "to_date": "20240529",
+        "max_items_per_dept": 1,
+    })
+    assert isinstance(result[0], TextContent)
+
+
+@pytest.mark.asyncio
+async def test_group_summary_by_department_section_filter(tools):
+    result = await tools.group_summary_by_department({
+        "from_date": "20240529",
+        "to_date": "20240529",
+        "sections": "1",
+    })
+    assert isinstance(result[0], TextContent)
+
+
+@pytest.mark.asyncio
+async def test_group_summary_by_department_shows_doc_count(tools):
+    """El output debe indicar cuántos documentos tiene cada departamento."""
+    result = await tools.group_summary_by_department({
+        "from_date": "20240529",
+        "to_date": "20240529",
+    })
+    text = result[0].text
+    # Debe haber al menos un encabezado con "(N docs)"
+    assert "docs" in text or "documento" in text.lower()


### PR DESCRIPTION
- Introduced shared fixtures in `conftest.py` for mocking HTTP client responses.
- Created tests for analysis tools in `test_analysis_tools.py`, covering summarization, pagination, explanation, and normalization of BOE references.
- Developed advanced auxiliary tools tests in `test_auxiliary_advanced.py`, focusing on department searches, topic listings, and filter suggestions.
- Implemented legislation tools tests in `test_legislation_advanced.py`, validating version comparisons, article searches, metadata retrieval, and related laws listing.
- Added summaries tools tests in `test_summaries_advanced.py`, ensuring functionality for BOE summary retrieval, change watching, and departmental grouping.