### PR TITLE
fix(legislacion): la busqueda leia la redaccion derogada, y los titul…

### DIFF
--- a/src/mcp_boe/utils/http_client.py
+++ b/src/mcp_boe/utils/http_client.py
@@ -419,8 +419,14 @@ class BOEHTTPClient:
             bloque_id = bloque_el.get("id", "")
             bloque_tipo = bloque_el.get("tipo", "")
 
-            titulo_el = bloque_el.find("titulo")
-            titulo = titulo_el.text.strip() if titulo_el is not None and titulo_el.text else ""
+            # En el XML del BOE el título es un ATRIBUTO del bloque
+            # (<bloque id="a194" tipo="precepto" titulo="Artículo 194">), no un
+            # hijo: buscarlo con find() devolvía siempre None y los títulos
+            # salían vacíos en la búsqueda y en la comparación de versiones.
+            titulo = (bloque_el.get("titulo") or "").strip()
+            if not titulo:
+                titulo_el = bloque_el.find("titulo")
+                titulo = titulo_el.text.strip() if titulo_el is not None and titulo_el.text else ""
 
             versiones = []
             for ver_el in bloque_el.findall("version"):
@@ -438,6 +444,16 @@ class BOEHTTPClient:
                     "fecha_vigencia": ver_el.get("fecha_vigencia", ""),
                     "contenido_html": contenido_html,
                 })
+
+            # El BOE emite las versiones de más antigua a más reciente, pero los
+            # consumidores que no filtran por fecha (search_law_articles) leen
+            # versiones[0]. Sin este orden buscarían sobre el texto ORIGINAL y
+            # ya derogado. compare_law_versions no se ve afectado: elige versión
+            # por fecha con _get_active_version, que ordena por su cuenta.
+            versiones.sort(
+                key=lambda v: v.get("fecha_vigencia") or v.get("fecha_publicacion") or "",
+                reverse=True,
+            )
 
             bloques.append({
                 "id": bloque_id,

--- a/tests/test_orden_versiones.py
+++ b/tests/test_orden_versiones.py
@@ -1,0 +1,141 @@
+"""
+Tests de la normalización del XML de /texto.
+
+Dos defectos que se manifiestan sobre datos reales del BOE y que el fixture
+SAMPLE_LAW_TEXTO de conftest no reproduce (allí las versiones ya vienen de
+más reciente a más antigua y el título es un campo del dict):
+
+  1. El BOE emite las <version> de MÁS ANTIGUA a MÁS RECIENTE, y
+     search_law_articles lee versiones[0]: buscaba sobre el texto derogado.
+  2. El título del bloque es un ATRIBUTO del XML, no un elemento hijo.
+"""
+
+import httpx
+import pytest
+from unittest.mock import AsyncMock
+
+from mcp_boe.tools.legislation import LegislationTools
+from mcp_boe.utils.http_client import BOEHTTPClient
+
+
+# ---------------------------------------------------------------------------
+# XML de ejemplo: /texto de la LGSS recortado al artículo 194.
+# Orden de versiones y título como atributo, tal y como los sirve el BOE.
+# La Ley 2/2025 sustituyó "gran invalidez" por "gran incapacidad".
+# ---------------------------------------------------------------------------
+
+TEXTO_XML = """<?xml version="1.0" encoding="utf-8"?>
+<response>
+  <status><code>200</code><text>ok</text></status>
+  <data>
+    <texto>
+      <bloque id="a194" tipo="precepto" titulo="Artículo 194">
+        <version id_norma="BOE-A-2015-11724" fecha_publicacion="20151031" fecha_vigencia="20160102">
+          <p class="articulo">Artículo 194. Grados de incapacidad permanente.</p>
+          <p class="parrafo">d) Gran invalidez.</p>
+        </version>
+        <version id_norma="BOE-A-2025-8567" fecha_publicacion="20250430" fecha_vigencia="20250501">
+          <p class="articulo">Artículo 194. Grados de incapacidad permanente.</p>
+          <p class="parrafo">d) Gran incapacidad.</p>
+        </version>
+      </bloque>
+    </texto>
+  </data>
+</response>
+"""
+
+
+@pytest.fixture
+def client_con_texto():
+    """Cliente real con _make_request simulado, sirviendo el XML de /texto."""
+    client = BOEHTTPClient()
+
+    async def _fake_request(method, url, params=None, headers=None, **kwargs):
+        return httpx.Response(200, text=TEXTO_XML)
+
+    client._make_request = AsyncMock(side_effect=_fake_request)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Normalización del XML
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_versiones_de_mas_reciente_a_mas_antigua(client_con_texto):
+    """versiones[0] debe ser la vigente, no la redacción original."""
+    respuesta = await client_con_texto.get_law_by_id("BOE-A-2015-11724", "texto")
+
+    versiones = respuesta["data"]["texto"][0]["versiones"]
+    assert [v["fecha_vigencia"] for v in versiones] == ["20250501", "20160102"]
+
+
+@pytest.mark.asyncio
+async def test_titulo_del_bloque_se_lee_del_atributo(client_con_texto):
+    """El título es un atributo del <bloque>, no un elemento hijo."""
+    respuesta = await client_con_texto.get_law_by_id("BOE-A-2015-11724", "texto")
+
+    assert respuesta["data"]["texto"][0]["titulo"] == "Artículo 194"
+
+
+# ---------------------------------------------------------------------------
+# search_law_articles
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_busqueda_encuentra_el_texto_vigente(client_con_texto):
+    """Buscar un término introducido por una reforma debe encontrarlo."""
+    tools = LegislationTools(client_con_texto)
+
+    resultado = await tools.search_law_articles({
+        "law_id": "BOE-A-2015-11724",
+        "query": "gran incapacidad",
+    })
+
+    texto = resultado[0].text
+    assert "No se encontraron" not in texto
+    assert "a194" in texto
+
+
+@pytest.mark.asyncio
+async def test_busqueda_no_devuelve_redaccion_derogada(client_con_texto):
+    """Un término que solo existe en la versión derogada no es texto vigente."""
+    tools = LegislationTools(client_con_texto)
+
+    resultado = await tools.search_law_articles({
+        "law_id": "BOE-A-2015-11724",
+        "query": "gran invalidez",
+    })
+
+    assert "No se encontraron" in resultado[0].text
+
+
+@pytest.mark.asyncio
+async def test_resultados_de_busqueda_llevan_titulo(client_con_texto):
+    """El artículo encontrado se identifica por su título, no solo por su id."""
+    tools = LegislationTools(client_con_texto)
+
+    resultado = await tools.search_law_articles({
+        "law_id": "BOE-A-2015-11724",
+        "query": "gran incapacidad",
+    })
+
+    assert "Artículo 194" in resultado[0].text
+
+
+# ---------------------------------------------------------------------------
+# No regresión: compare_law_versions elige versión por fecha
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_comparacion_sigue_detectando_la_modificacion(client_con_texto):
+    """compare_law_versions usa _get_active_version, que ordena por su cuenta."""
+    tools = LegislationTools(client_con_texto)
+
+    resultado = await tools.compare_law_versions({
+        "law_id": "BOE-A-2015-11724",
+        "from_date": "20200101",
+        "to_date": "20260101",
+    })
+
+    assert "modificad" in resultado[0].text.lower()


### PR DESCRIPTION
…os salian vacios

Dos defectos en la normalizacion del XML consolidado, ambos invisibles para la suite porque el fixture SAMPLE_LAW_TEXTO no reproduce la forma real que sirve el BOE.

1. ORDEN DE VERSIONES. El BOE emite las <version> de mas antigua a mas reciente. search_law_articles lee versiones[0], asi que buscaba sobre la redaccion ORIGINAL de la norma, ya derogada, y presentaba el resultado como texto de la norma vigente.

   Caso real: en la LGSS (BOE-A-2015-11724), buscar "gran incapacidad" devolvia cero resultados, porque la version de 2016 del articulo 194 todavia dice "gran invalidez" — expresion que la disposicion adicional unica de la Ley 2/2025 (BOE-A-2025-8567) sustituyo. Un falso negativo silencioso sobre derecho vigente.

   Las versiones pasan a ordenarse de mas reciente a mas antigua. compare_law_versions no se ve afectado: elige version por fecha con _get_active_version, que ya ordena sus propios candidatos.

2. TITULO DEL BLOQUE. En el XML el titulo es un ATRIBUTO del <bloque>, no un elemento hijo, asi que el find("titulo") devolvia siempre None y todos los titulos salian vacios: los resultados de busqueda se mostraban como "### `a194` — " y la comparacion como "Sin titulo". Se lee del atributo, conservando el hijo como respaldo.

Tests nuevos en tests/test_orden_versiones.py (6): 5 fallan sin el arreglo; el sexto es un guardian de no-regresion de compare_law_versions y pasa en ambos casos a proposito. Suite completa verde.